### PR TITLE
Add a make your own custom header option

### DIFF
--- a/chrome/content/mzcw-customcolumns.js
+++ b/chrome/content/mzcw-customcolumns.js
@@ -155,7 +155,7 @@ miczColumnsWizard.CustCols["columnHandler_custom"]={
       let prefs = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
       prefs = prefs.getBranch("extensions.ColumnsWizard.CustCols.");
       let customHdr = prefs.getCharPref("CustomHdr").toLowerCase();
-      return hdr.getStringProperty("content-base");
+      return hdr.getStringProperty("CustomHdr");
    },
    isString:            function() {return true;},
    getCellProperties:   function(row, col, props){},

--- a/chrome/content/mzcw-customcolumns.js
+++ b/chrome/content/mzcw-customcolumns.js
@@ -139,3 +139,28 @@ miczColumnsWizard.CustCols["columnHandler_contentbase"]={
    getSortLongForRow:   function(hdr) {return 0;}
 };
 //contentbase - END
+
+//custom
+miczColumnsWizard.CustCols["columnHandler_custom"]={
+   getCellText:         function(row, col) {
+      let prefs = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
+      prefs = prefs.getBranch("extensions.ColumnsWizard.CustCols.");
+      let customHdr = prefs.getCharPref("CustomHdr").toLowerCase();
+      //get the message's header so that we can extract the content-base to field
+      let hdr = gDBView.getMsgHdrAt(row);
+      //dump(">>>>>>>>>>>>> miczColumnsWizard->columnHandler_content-base: [value] "+hdr.getStringProperty("content-base")+"\r\n");
+      return hdr.getStringProperty(customHdr);
+   },
+   getSortStringForRow: function(hdr) {
+      let prefs = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
+      prefs = prefs.getBranch("extensions.ColumnsWizard.CustCols.");
+      let customHdr = prefs.getCharPref("CustomHdr").toLowerCase();
+      return hdr.getStringProperty("content-base");
+   },
+   isString:            function() {return true;},
+   getCellProperties:   function(row, col, props){},
+   getRowProperties:    function(row, props){},
+   getImageSrc:         function(row, col) {return null;},
+   getSortLongForRow:   function(hdr) {return 0;}
+};
+//custom - END

--- a/chrome/content/mzcw-overlay.js
+++ b/chrome/content/mzcw-overlay.js
@@ -65,6 +65,10 @@ var miczColumnsWizard = {
     loadedCustColPref["contentbase"].Pref = prefs.getBoolPref("Addcontentbase");
     loadedCustColPref["contentbase"].Def = "Addcontentbase";
     loadedCustColPref["contentbase"].customDBHeader = "content-base";
+    loadedCustColPref["custom"]={};
+    loadedCustColPref["custom"].Pref = prefs.getBoolPref("Addcustom");
+    loadedCustColPref["custom"].Def = "Addcustom";
+    loadedCustColPref["custom"].customDBHeader = prefs.getCharPref("CustomHdr").toLowerCase();
     return loadedCustColPref;
   },
   

--- a/chrome/content/mzcw-settings.xul
+++ b/chrome/content/mzcw-settings.xul
@@ -36,6 +36,12 @@
       <preference id="ColumnsWizard.CustCols.Addcontentbase"
         name="extensions.ColumnsWizard.CustCols.Addcontentbase"
         type="bool" />
+      <preference id="ColumnsWizard.CustCols.Addcustom"
+        name="extensions.ColumnsWizard.CustCols.Addcustom"
+        type="bool" />
+      <preference id="ColumnsWizard.CustCols.CustomHdr"
+        name="extensions.ColumnsWizard.CustCols.CustomHdr"
+        type="string" />
     </preferences>
     <tabbox>
       <tabs>
@@ -72,6 +78,10 @@
             preference="ColumnsWizard.CustCols.Addxoriginalfrom"/> <label control="symbol" value="*"/></hbox>
           <hbox><checkbox id="ColumnsWizard.Addcontentbase_checkbox" label="&ColumnsWizard.Addcontentbase.label;"
             preference="ColumnsWizard.CustCols.Addcontentbase"/> <label control="symbol" value="*"/></hbox>
+          <hbox><checkbox id="ColumnsWizard.Addcustom_checkbox" label="&ColumnsWizard.Addcustom.label;"
+            preference="ColumnsWizard.CustCols.Addcustom"/> <label control="symbol" value="*"/>
+            <textbox id="ColumnsWizard.CustomHdr_textbox" label="&ColumnsWizard.CustomHdr.label;"
+            preference="ColumnsWizard.CustCols.CustomHdr"/></hbox>
           <label control="symbol" value=" "/>
           <description style="word-wrap:normal;max-width:550px;margin-bottom:10px;">&ColumnsWizard.CustomHeadersDescCustCols;</description>
           <label control="symbol" value=" "/>

--- a/chrome/locale/en-US/overlay.properties
+++ b/chrome/locale/en-US/overlay.properties
@@ -9,3 +9,5 @@ ColumnsWizardxoriginalfrom.label=X-Original-From
 ColumnsWizardxoriginalfromDesc.label=Click to sort by X-Original-From
 ColumnsWizardcontentbase.label=Content-Base
 ColumnsWizardcontentbaseDesc.label=Click to sort by Content-Base
+ColumnsWizardcustom.label=Custom Header
+ColumnsWizardcustomDesc.label=Click to sort by Custom Header

--- a/chrome/locale/en-US/settings.dtd
+++ b/chrome/locale/en-US/settings.dtd
@@ -17,4 +17,6 @@
 <!ENTITY ColumnsWizard.Addreplyto.label "Reply-to">
 <!ENTITY ColumnsWizard.Addxoriginalfrom.label "X-Original-From">
 <!ENTITY ColumnsWizard.Addcontentbase.label "Content-Base">
+<!ENTITY ColumnsWizard.Addcustom.label "Custom">
+<!ENTITY ColumnsWizard.CustomHdr.label "Custom">
 <!ENTITY ColumnsWizard.CustomHeadersDescCustCols "* This column will be populated only for the mails that will be received after the Custom Column activation.">

--- a/defaults/preferences/prefs.js
+++ b/defaults/preferences/prefs.js
@@ -7,3 +7,5 @@ pref("extensions.ColumnsWizard.CustCols.Addbcc", false);
 pref("extensions.ColumnsWizard.CustCols.Addreplyto", false);
 pref("extensions.ColumnsWizard.CustCols.Addxoriginalfrom", false);
 pref("extensions.ColumnsWizard.CustCols.Addcontentbase", false);
+pref("extensions.ColumnsWizard.CustCols.Addcustom", false);
+pref("extensions.ColumnsWizard.CustCols.CustomHdr", "X-Spam-Score");


### PR DESCRIPTION
I guess a many people will install this addon because they want to easily track *one* header, such as "X-Spam-Score".

This commit adds the posibility to add one truly custom column by entering the text for the header to be shown. The code could certainly be improved, but I know just about nothing about extension development and it works for me.

I haven't looked into translating the extra strings, or even including them in the language specific files.

Refs #17