### PR TITLE
Reformat jscommon

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,8 +7,8 @@
 	},
 
 	"extends": [
-		"eslint:recommended",
-		"plugin:mozilla/recommended"
+		"eslint:recommended"
+		// "plugin:mozilla/recommended"
 	  ],
 	
 	"overrides": [
@@ -24,6 +24,11 @@
 	"globals": {
 		"EXPORTED_SYMBOLS": "readonly",
 		"ChromeUtils": "readonly",
+		"sizeToContent": "readonly",
+		"Cc": "readonly",
+		"Cu": "readonly",
+		"Ci": "readonly",
+		"Cr": "readonly",
 		"miczLogger": "readonly",
 		"miczColumnsWizardPrefsUtils": "readonly",
 		"Components": "readonly", 
@@ -47,8 +52,8 @@
 	"rules": {
 		"no-irregular-whitespace": "error",
 		"space-in-parens": "error",
-	    "no-unused-vars": [1, {"vars": "all", "args": "none", "varsIgnorePattern": "EXPORTED_SYMBOLS|rest"}],
-
+	    // "no-unused-vars": [1, {"vars": "all", "args": "none", "varsIgnorePattern": "EXPORTED_SYMBOLS|rest"}],
+		"no-unused-vars":"off",
 		"space-before-function-paren":"off",
 		"no-array-constructor": "warn",
 		"eqeqeq":"error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,9 +1,15 @@
-{
+	{
 	"env": {
 		"browser": true,
 		"es6": true,
+		"mozilla/jsm": true,
 		"commonjs": true
-	  },
+	},
+
+	"extends": [
+		"eslint:recommended",
+		"plugin:mozilla/recommended"
+	  ],
 	
 	"overrides": [
 		{
@@ -11,22 +17,72 @@
 		}
 	],
 	"plugins": [
-		"deprecate"
-],
+		"deprecate",
+		"mozilla"
+	],
+	
+	"globals": {
+		"EXPORTED_SYMBOLS": "readonly",
+		"ChromeUtils": "readonly",
+		"miczLogger": "readonly",
+		"miczColumnsWizardPrefsUtils": "readonly",
+		"Components": "readonly", 
+		"miczColumnsWizard": "readonly",
+		"miczColumnsWizard_CustCols": "readonly",
+		"miczColumnsWizard_MsgUtils": "readonly",
+		"miczColumnsWizardUtils": "readonly",
+		"miczColumnsWizard_CustomColsModUtils": "readonly",
+		"miczColumnsWizardPref_DefaultColsGrid": "readonly",
+		"miczColumnsWizardPref_CustomColsGrid": "readonly",
+
+		"messenger": "readonly",
+		"MailServices": "readonly",
+		"gDBView": "readonly",
+		"OS": "readonly",
+		"window": "readonly",
+		"msgWindow": "readonly",
+		"gFolderDisplay": "readonly"
+		
+	},
+	"rules": {
+		"no-irregular-whitespace": "error",
+		"space-in-parens": "error",
+	    "no-unused-vars": [1, {"vars": "all", "args": "none", "varsIgnorePattern": "EXPORTED_SYMBOLS|rest"}],
+
+		"space-before-function-paren":"off",
+		"no-array-constructor": "warn",
+		"eqeqeq":"error",
+
+		"mozilla/import-globals": "off",
+		"no-tabs":"off",
+		"no-useless-return":"off",
+		"object-shorthand":"off",
+		"padded-blocks":"off",
+		"mozilla/use-cc-etc": "error",
+		"mozilla/no-useless-parameters": "off",
+		"mozilla/use-services": "off",
+		"mozilla/use-includes-instead-of-indexOf": "warn",
+		"mozilla/avoid-removeChild": "warn",
 
 
-"rules": {
-"no-unused-vars":"error",
-"spaced-comment": [2,"always"],
-"semi":"error",
-
-"no-restricted-properties": [2, {
-	"property": "nsIStringBundleService"
-}],
-
-"deprecate/function": ["error",
-	{"name": "createBundle",
-	 "use": "Replace with Services.createBundle"}
-	]
-}
+		"quotes":"off",
+		"spaced-comment": [
+			2,
+			"always"
+		],
+		"semi": "error",
+		"no-restricted-properties": [
+			1,
+			{
+				"property": "nsIStringBundleService"
+			}
+		],
+		"deprecate/function": [
+			"error",
+			{
+				"name": "createBundle",
+				"use": "Replace with Services.createBundle"
+			}
+		]
+	}
 }

--- a/src/chrome/content/mzcw-customcolsgrid.jsm
+++ b/src/chrome/content/mzcw-customcolsgrid.jsm
@@ -4,78 +4,78 @@ var EXPORTED_SYMBOLS = ["miczColumnsWizardPref_CustomColsGrid"];
 
 var miczColumnsWizardPref_CustomColsGrid = {
 
-	miczColumnsWizard_CustCols:{},
-	win:{},
-	onEditCustomCol:{},
+	miczColumnsWizard_CustCols: {},
+	win: {},
+	onEditCustomCol: {},
 
-	createCustomColsListRows: function(doc,container,CustColRows){
-		//sort cust cols by dbHeader
-		let tmp_array=[];
+	createCustomColsListRows: function (doc, container, CustColRows) {
+		// sort cust cols by dbHeader
+		let tmp_array = [];
 		for (let index in CustColRows) {
 			tmp_array.push(index);
 		}
-		tmp_array.sort(function(a, b){return a < b ? -1 : (a > b ? 1 : 0);});
+		tmp_array.sort(function (a, b) { return a < b ? -1 : (a > b ? 1 : 0); });
 
 		for (let index in tmp_array) {
-			this.createOneCustomColRow(doc,container,CustColRows[tmp_array[index]]);
+			this.createOneCustomColRow(doc, container, CustColRows[tmp_array[index]]);
 		}
 	},
 
-	createOneCustomColRow:function(doc,container,currcol){
-		let strBundleCW = Components.classes["@mozilla.org/intl/stringbundle;1"].getService(Components.interfaces.nsIStringBundleService);
+	createOneCustomColRow: function (doc, container, currcol) {
+		let strBundleCW = Cc["@mozilla.org/intl/stringbundle;1"].getService(Ci.nsIStringBundleService);
 		let _bundleCW = strBundleCW.createBundle("chrome://columnswizard/locale/overlay.properties");
 
 		if (!container) return;
 		let listitem = doc.createElement("listitem");
 
-		//dump(">>>>>>>>>>>>> miczColumnsWizard: [createOneCustomColRow] currcol {"+JSON.stringify(currcol)+"}\r\n");
+		// dump(">>>>>>>>>>>>> miczColumnsWizard: [createOneCustomColRow] currcol {"+JSON.stringify(currcol)+"}\r\n");
 
 		let activeCell = doc.createElement("listcell");
 		activeCell.setAttribute("class", "listcell-iconic");
-		activeCell.setAttribute("enabled",currcol.enabled);
-		if(currcol.isCustom){
-			activeCell.setAttribute("label","*");
+		activeCell.setAttribute("enabled", currcol.enabled);
+		if (currcol.isCustom) {
+			activeCell.setAttribute("label", "*");
 		}
 		listitem.appendChild(activeCell);
-		
+
 		let searchableCell = doc.createElement("listcell");
 		searchableCell.setAttribute("class", "listcell-iconic searchable");
-		searchableCell.setAttribute("enabled",currcol.isSearchable);
+		searchableCell.setAttribute("enabled", currcol.isSearchable);
 		listitem.appendChild(searchableCell);
 
 		let idCell = doc.createElement("listcell");
-		idCell.setAttribute("label",currcol.index);
+		idCell.setAttribute("label", currcol.index);
 		listitem.appendChild(idCell);
 
 		let mailheaderCell = doc.createElement("listcell");
-		mailheaderCell.setAttribute("label",currcol.dbHeader);
+		mailheaderCell.setAttribute("label", currcol.dbHeader);
 		listitem.appendChild(mailheaderCell);
 
 		let labelString = '';
 		let tooltipString = '';
-		if(currcol.isBundled){
-			labelString = _bundleCW.GetStringFromName("ColumnsWizard"+currcol.index+".label");
-			tooltipString = _bundleCW.GetStringFromName("ColumnsWizard"+currcol.index+"Desc.label");
-		}else{
+		if (currcol.isBundled) {
+			labelString = _bundleCW.GetStringFromName("ColumnsWizard" + currcol.index + ".label");
+			tooltipString = _bundleCW.GetStringFromName("ColumnsWizard" + currcol.index + "Desc.label");
+		} else {
 			labelString = currcol.labelString;
 			tooltipString = currcol.tooltipString;
 		}
 
 		let titleCell = doc.createElement("listcell");
-		titleCell.setAttribute("label",labelString);
-		if((!currcol.labelImagePath)||(currcol.labelImagePath=="")){	//no image for this cust col
-			titleCell.setAttribute("image","");
-		}else{
-			titleCell.setAttribute("image","file://"+currcol.labelImagePath);
+		titleCell.setAttribute("label", labelString);
+		if ((!currcol.labelImagePath) || (currcol.labelImagePath === "")) {	// no image for this cust col
+			titleCell.setAttribute("image", "");
+		} else {
+			titleCell.setAttribute("image", "file://" + currcol.labelImagePath);
 			titleCell.setAttribute("class", "listcell-iconic cw_col_icon");
 		}
 		listitem.appendChild(titleCell);
 
 		let tooltipCell = doc.createElement("listcell");
-		tooltipCell.setAttribute("label",tooltipString);
+		tooltipCell.setAttribute("label", tooltipString);
 		listitem.appendChild(tooltipCell);
 
-		listitem._customcol=currcol;
+		listitem._customcol = currcol;
 
 		container.appendChild(listitem);
 		// We have to attach this listener to the listitem, even though we only care
@@ -86,61 +86,61 @@ var miczColumnsWizardPref_CustomColsGrid = {
 		return listitem;
 	},
 
-	editOneCustomColRow:function(doc,container,currcol,idx_col){
-		let strBundleCW = Components.classes["@mozilla.org/intl/stringbundle;1"].getService(Components.interfaces.nsIStringBundleService);
+	editOneCustomColRow: function (doc, container, currcol, idx_col) {
+		let strBundleCW = Cc["@mozilla.org/intl/stringbundle;1"].getService(Ci.nsIStringBundleService);
 		let _bundleCW = strBundleCW.createBundle("chrome://columnswizard/locale/overlay.properties");
 
 		if (!container) return;
 		let listitem = container.getItemAtIndex(idx_col);
-		if(!listitem) return;
+		if (!listitem) return;
 
-		//dump(">>>>>>>>>>>>> miczColumnsWizard: [editOneCustomColRow] listitem "+JSON.stringify(listitem)+"\r\n");
+		// dump(">>>>>>>>>>>>> miczColumnsWizard: [editOneCustomColRow] listitem "+JSON.stringify(listitem)+"\r\n");
 
 		let activeCell = listitem.childNodes[0];
-		activeCell.setAttribute("enabled",currcol.enabled);
-		if(currcol.isCustom){
-			activeCell.setAttribute("label","*");
+		activeCell.setAttribute("enabled", currcol.enabled);
+		if (currcol.isCustom) {
+			activeCell.setAttribute("label", "*");
 		}
-		
+
 		let searchableCell = listitem.childNodes[1];
-		searchableCell.setAttribute("enabled",currcol.isSearchable);
+		searchableCell.setAttribute("enabled", currcol.isSearchable);
 
 		let idCell = listitem.childNodes[2];
-		idCell.setAttribute("label",currcol.index);
+		idCell.setAttribute("label", currcol.index);
 
 		let mailheaderCell = listitem.childNodes[3];
-		mailheaderCell.setAttribute("label",currcol.dbHeader);
+		mailheaderCell.setAttribute("label", currcol.dbHeader);
 
 		let labelString = '';
 		let tooltipString = '';
-		if(currcol.isBundled){
-			labelString = _bundleCW.GetStringFromName("ColumnsWizard"+currcol.index+".label");
-			tooltipString = _bundleCW.GetStringFromName("ColumnsWizard"+currcol.index+"Desc.label");
-		}else{
+		if (currcol.isBundled) {
+			labelString = _bundleCW.GetStringFromName("ColumnsWizard" + currcol.index + ".label");
+			tooltipString = _bundleCW.GetStringFromName("ColumnsWizard" + currcol.index + "Desc.label");
+		} else {
 			labelString = currcol.labelString;
 			tooltipString = currcol.tooltipString;
 		}
 
 		let titleCell = listitem.childNodes[4];
-		titleCell.setAttribute("label",labelString);
-		if((!currcol.labelImagePath)||(currcol.labelImagePath=="")){	//no image for this cust col
-			titleCell.setAttribute("image","");
-		}else{
-			titleCell.setAttribute("image","file://"+currcol.labelImagePath);
+		titleCell.setAttribute("label", labelString);
+		if ((!currcol.labelImagePath) || (currcol.labelImagePath === "")) {	// no image for this cust col
+			titleCell.setAttribute("image", "");
+		} else {
+			titleCell.setAttribute("image", "file://" + currcol.labelImagePath);
 			titleCell.setAttribute("class", "listcell-iconic cw_col_icon");
 		}
 
 		let tooltipCell = listitem.childNodes[5];
-		tooltipCell.setAttribute("label",tooltipString);
+		tooltipCell.setAttribute("label", tooltipString);
 
-		listitem._customcol=currcol;
+		listitem._customcol = currcol;
 
 		return listitem;
 	},
 
-	/*saveCustomColItem: function(currcol) {
+	/* saveCustomColItem: function(currcol) {
 		let value = JSON.stringify(currcol);
-		let prefsc = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
+		let prefsc = Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefService);
 		//Saving custom columns item to prefs
 		let prefs_def = prefsc.getBranch("extensions.ColumnsWizard.CustCols.def.");
 		prefs_def.setCharPref(currcol.index,value);
@@ -154,71 +154,69 @@ var miczColumnsWizardPref_CustomColsGrid = {
     	return value;
 	},*/
 
-	deleteOneCustomColRow: function(container,col_idx){
+	deleteOneCustomColRow: function (container, col_idx) {
 		container.removeItemAt(col_idx);
 	},
 
-	currentCustomCol: function(currlist)
-	{
-	  let currentItem = currlist.selectedItem;
-	  return currentItem ? currentItem._customcol : null;
+	currentCustomCol: function (currlist) {
+		let currentItem = currlist.selectedItem;
+		return currentItem ? currentItem._customcol : null;
 	},
 
-	onItemClick: function(event)
-	{
+	onItemClick: function (event) {
 		// we only care about button 0 (left click) events
-		if (event.button != 0)
-		  return;
+		if (event.button !== 0)
+			return;
 
 		// Remember, we had to attach the click-listener to the whole listitem, so
 		// now we need to see if the clicked the enable-column
-		let toggle_enable = event.target.childNodes[0];	//enable
-		//dump(">>>>>>>>>>>>> miczColumnsWizard: [onFilterClick] toggle range: from "+toggle.boxObject.x+" to "+(toggle.boxObject.x + toggle.boxObject.width)+"\r\n");
-		//dump(">>>>>>>>>>>>> miczColumnsWizard: [onFilterClick] event.clientX "+event.clientX+"\r\n");
+		let toggle_enable = event.target.childNodes[0];	// enable
+		// dump(">>>>>>>>>>>>> miczColumnsWizard: [onFilterClick] toggle range: from "+toggle.boxObject.x+" to "+(toggle.boxObject.x + toggle.boxObject.width)+"\r\n");
+		// dump(">>>>>>>>>>>>> miczColumnsWizard: [onFilterClick] event.clientX "+event.clientX+"\r\n");
 		if ((event.clientX < toggle_enable.boxObject.x + toggle_enable.boxObject.width) &&
 			(event.clientX > toggle_enable.boxObject.x)) {
-		  miczColumnsWizardPref_CustomColsGrid.toggleEnable(event.target);
-		  event.stopPropagation();
+			miczColumnsWizardPref_CustomColsGrid.toggleEnable(event.target);
+			event.stopPropagation();
 		}
-		
-		let toggle_searchable = event.target.childNodes[1];	//is searchable
-		//dump(">>>>>>>>>>>>> miczColumnsWizard: [onFilterClick] toggle range: from "+toggle.boxObject.x+" to "+(toggle.boxObject.x + toggle.boxObject.width)+"\r\n");
-		//dump(">>>>>>>>>>>>> miczColumnsWizard: [onFilterClick] event.clientX "+event.clientX+"\r\n");
+
+		let toggle_searchable = event.target.childNodes[1];	// is searchable
+		// dump(">>>>>>>>>>>>> miczColumnsWizard: [onFilterClick] toggle range: from "+toggle.boxObject.x+" to "+(toggle.boxObject.x + toggle.boxObject.width)+"\r\n");
+		// dump(">>>>>>>>>>>>> miczColumnsWizard: [onFilterClick] event.clientX "+event.clientX+"\r\n");
 		if ((event.clientX < toggle_searchable.boxObject.x + toggle_searchable.boxObject.width) &&
 			(event.clientX > toggle_searchable.boxObject.x)) {
-		  miczColumnsWizardPref_CustomColsGrid.toggleSearchable(event.target);
-		  event.stopPropagation();
+			miczColumnsWizardPref_CustomColsGrid.toggleSearchable(event.target);
+			event.stopPropagation();
 		}
 	},
 
-	toggleEnable: function(aCustColItem){
-	  let currcol = aCustColItem._customcol;
-	  currcol.enabled = !currcol.enabled;
-	  //dump(">>>>>>>>>>>>> miczColumnsWizard: [currcol] "+JSON.stringify(currcol)+"\r\n");
+	toggleEnable: function (aCustColItem) {
+		let currcol = aCustColItem._customcol;
+		currcol.enabled = !currcol.enabled;
+		// dump(">>>>>>>>>>>>> miczColumnsWizard: [currcol] "+JSON.stringify(currcol)+"\r\n");
 
-	  //miczColumnsWizardPref_CustomColsGrid.saveCustomColItem(currcol);
-	  this.miczColumnsWizard_CustCols.saveCustCol(currcol);
+		// miczColumnsWizardPref_CustomColsGrid.saveCustomColItem(currcol);
+		this.miczColumnsWizard_CustCols.saveCustCol(currcol);
 
-	  // Now update the checkbox
-	  aCustColItem.childNodes[0].setAttribute("enabled", currcol.enabled);
+		// Now update the checkbox
+		aCustColItem.childNodes[0].setAttribute("enabled", currcol.enabled);
 	},
 
-	toggleSearchable: function(aCustColItem){
-	  let currcol = aCustColItem._customcol;
-	  currcol.isSearchable = !currcol.isSearchable;
-	  //dump(">>>>>>>>>>>>> miczColumnsWizard: [currcol] "+JSON.stringify(currcol)+"\r\n");
+	toggleSearchable: function (aCustColItem) {
+		let currcol = aCustColItem._customcol;
+		currcol.isSearchable = !currcol.isSearchable;
+		// dump(">>>>>>>>>>>>> miczColumnsWizard: [currcol] "+JSON.stringify(currcol)+"\r\n");
 
-	  //miczColumnsWizardPref_CustomColsGrid.saveCustomColItem(currcol);
-	  this.miczColumnsWizard_CustCols.saveCustCol(currcol);
+		// miczColumnsWizardPref_CustomColsGrid.saveCustomColItem(currcol);
+		this.miczColumnsWizard_CustCols.saveCustCol(currcol);
 
-	  // Now update the checkbox
-	  aCustColItem.childNodes[1].setAttribute("enabled", currcol.isSearchable);
+		// Now update the checkbox
+		aCustColItem.childNodes[1].setAttribute("enabled", currcol.isSearchable);
 	},
 
-	onItemDoubleClick:function(event){
+	onItemDoubleClick: function (event) {
 		// we only care about button 0 (left click) events
-		if (event.button != 0)
-		  return;
+		if (event.button !== 0)
+			return;
 
 		miczColumnsWizardPref_CustomColsGrid.onEditCustomCol(miczColumnsWizardPref_CustomColsGrid.win);
 	},

--- a/src/chrome/content/mzcw-customcolsgrid.jsm
+++ b/src/chrome/content/mzcw-customcolsgrid.jsm
@@ -1,5 +1,7 @@
 "use strict";
 
+const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+
 var EXPORTED_SYMBOLS = ["miczColumnsWizardPref_CustomColsGrid"];
 
 var miczColumnsWizardPref_CustomColsGrid = {
@@ -22,8 +24,7 @@ var miczColumnsWizardPref_CustomColsGrid = {
 	},
 
 	createOneCustomColRow: function (doc, container, currcol) {
-		let strBundleCW = Cc["@mozilla.org/intl/stringbundle;1"].getService(Ci.nsIStringBundleService);
-		let _bundleCW = strBundleCW.createBundle("chrome://columnswizard/locale/overlay.properties");
+		let _bundleCW = Services.strings.createBundle("chrome://columnswizard/locale/overlay.properties");
 
 		if (!container) return;
 		let listitem = doc.createElement("listitem");
@@ -87,8 +88,7 @@ var miczColumnsWizardPref_CustomColsGrid = {
 	},
 
 	editOneCustomColRow: function (doc, container, currcol, idx_col) {
-		let strBundleCW = Cc["@mozilla.org/intl/stringbundle;1"].getService(Ci.nsIStringBundleService);
-		let _bundleCW = strBundleCW.createBundle("chrome://columnswizard/locale/overlay.properties");
+		let _bundleCW = Services.strings.createBundle("chrome://columnswizard/locale/overlay.properties");
 
 		if (!container) return;
 		let listitem = container.getItemAtIndex(idx_col);

--- a/src/chrome/content/mzcw-customcolsmodutils.jsm
+++ b/src/chrome/content/mzcw-customcolsmodutils.jsm
@@ -4,76 +4,76 @@ var EXPORTED_SYMBOLS = ["miczColumnsWizard_CustomColsModUtils"];
 
 var miczColumnsWizard_CustomColsModUtils = {
 
-	editTypeFreeText:'tx',
-	editTypeNumbers:'nb',
-	editTypeFixedList:'fl',
+	editTypeFreeText: 'tx',
+	editTypeNumbers: 'nb',
+	editTypeFixedList: 'fl',
 
-	getFixedListArray:function(textbox_value){
-		let fl_string=textbox_value.replace(/(?:\r\n|\r|\n)/g, '|');
+	getFixedListArray: function (textbox_value) {
+		let fl_string = textbox_value.replace(/(?:\r\n|\r|\n)/g, '|');
 		return fl_string.split('|');
 	},
 
-	addContextMenu:function(doc,container1,container2,container3,CustCols,stringCustColIndexMod,first_click_callback,submenu_click_callback){
-		//clear menu items
+	addContextMenu: function (doc, container1, container2, container3, CustCols, stringCustColIndexMod, first_click_callback, submenu_click_callback) {
+		// clear menu items
 		while (container1.firstChild) {
-			container1.removeChild(container1.firstChild);
+			container1.firstChild.remove();
 		}
 		while (container2.firstChild) {
-			container2.removeChild(container2.firstChild);
+			container2.firstChild.remove();
 		}
 		while (container3.firstChild) {
-			container3.removeChild(container3.firstChild);
+			container3.firstChild.remove();
 		}
 
-		let arrayCustColIndexMod=new Array();
+		let arrayCustColIndexMod = [];
 
-		if(stringCustColIndexMod!=''){
-			arrayCustColIndexMod=JSON.parse(stringCustColIndexMod);
+		if (stringCustColIndexMod !== '') {
+			arrayCustColIndexMod = JSON.parse(stringCustColIndexMod);
 		}
 
-		for(let icc in arrayCustColIndexMod){
-			let cc=arrayCustColIndexMod[icc];
-			if(CustCols[cc].isEditable){
+		for (let icc in arrayCustColIndexMod) {
+			let cc = arrayCustColIndexMod[icc];
+			if (CustCols[cc].isEditable) {
 				let new_menu_item;
 				let new_menu_item2;
 				let new_menu_item3;
-				if(CustCols[cc].editType!=miczColumnsWizard_CustomColsModUtils.editTypeFixedList){	//simple menu
+				if (CustCols[cc].editType !== miczColumnsWizard_CustomColsModUtils.editTypeFixedList) {	// simple menu
 					new_menu_item = doc.createElement("menuitem");
-					new_menu_item.setAttribute('label',CustCols[cc].labelString);
-					new_menu_item.setAttribute('colidx',CustCols[cc].index);
-					new_menu_item.setAttribute('mail_header',CustCols[cc].dbHeader);
-					new_menu_item.setAttribute('edit_type',CustCols[cc].editType);
-					new_menu_item.onclick=first_click_callback;
-					new_menu_item2=new_menu_item.cloneNode(true);
-					new_menu_item2.onclick=first_click_callback;
-					new_menu_item3=new_menu_item.cloneNode(true);
-					new_menu_item3.onclick=first_click_callback;
-				}else{	//it's a fixed list, add submenus
+					new_menu_item.setAttribute('label', CustCols[cc].labelString);
+					new_menu_item.setAttribute('colidx', CustCols[cc].index);
+					new_menu_item.setAttribute('mail_header', CustCols[cc].dbHeader);
+					new_menu_item.setAttribute('edit_type', CustCols[cc].editType);
+					new_menu_item.onclick = first_click_callback;
+					new_menu_item2 = new_menu_item.cloneNode(true);
+					new_menu_item2.onclick = first_click_callback;
+					new_menu_item3 = new_menu_item.cloneNode(true);
+					new_menu_item3.onclick = first_click_callback;
+				} else {	// it's a fixed list, add submenus
 					new_menu_item = doc.createElement("menu");
-					new_menu_item.setAttribute('label',CustCols[cc].labelString);
-					new_menu_item.setAttribute('colidx',CustCols[cc].index);
-					new_menu_item.setAttribute('mail_header',CustCols[cc].dbHeader);
-					new_menu_item.setAttribute('edit_type',CustCols[cc].editType);
-					new_menu_item2=new_menu_item.cloneNode(true);
-					new_menu_item3=new_menu_item.cloneNode(true);
-					let mpp=doc.createElement("menupopup");
-					let mpp2=doc.createElement("menupopup");
-					let mpp3=doc.createElement("menupopup");
-					mpp.setAttribute("onpopupshowing","miczColumnsWizard.checkHeadersEditingMenuList(this);");
-					mpp2.setAttribute("onpopupshowing","miczColumnsWizard.checkHeadersEditingMenuList(this);");
-					mpp3.setAttribute("onpopupshowing","miczColumnsWizard.checkHeadersEditingMenuList(this);");
-					for(let sbi in CustCols[cc].editFixedList){
+					new_menu_item.setAttribute('label', CustCols[cc].labelString);
+					new_menu_item.setAttribute('colidx', CustCols[cc].index);
+					new_menu_item.setAttribute('mail_header', CustCols[cc].dbHeader);
+					new_menu_item.setAttribute('edit_type', CustCols[cc].editType);
+					new_menu_item2 = new_menu_item.cloneNode(true);
+					new_menu_item3 = new_menu_item.cloneNode(true);
+					let mpp = doc.createElement("menupopup");
+					let mpp2 = doc.createElement("menupopup");
+					let mpp3 = doc.createElement("menupopup");
+					mpp.setAttribute("onpopupshowing", "miczColumnsWizard.checkHeadersEditingMenuList(this);");
+					mpp2.setAttribute("onpopupshowing", "miczColumnsWizard.checkHeadersEditingMenuList(this);");
+					mpp3.setAttribute("onpopupshowing", "miczColumnsWizard.checkHeadersEditingMenuList(this);");
+					for (let sbi in CustCols[cc].editFixedList) {
 						let subm = doc.createElement("menuitem");
-						subm.setAttribute('id',CustCols[cc].dbHeader+'_'+CustCols[cc].editFixedList[sbi]);
-						subm.setAttribute('label',CustCols[cc].editFixedList[sbi]);
-						subm.setAttribute('colidx',CustCols[cc].index);
-						subm.setAttribute('mail_header',CustCols[cc].dbHeader);
-						subm.setAttribute('type','checkbox');
-						subm.onclick=submenu_click_callback;
-						let subm2=subm.cloneNode(true);
-						subm2.onclick=submenu_click_callback;
-						let subm3=subm.cloneNode(true);
-						subm3.onclick=submenu_click_callback;
+						subm.setAttribute('id', CustCols[cc].dbHeader + '_' + CustCols[cc].editFixedList[sbi]);
+						subm.setAttribute('label', CustCols[cc].editFixedList[sbi]);
+						subm.setAttribute('colidx', CustCols[cc].index);
+						subm.setAttribute('mail_header', CustCols[cc].dbHeader);
+						subm.setAttribute('type', 'checkbox');
+						subm.onclick = submenu_click_callback;
+						let subm2 = subm.cloneNode(true);
+						subm2.onclick = submenu_click_callback;
+						let subm3 = subm.cloneNode(true);
+						subm3.onclick = submenu_click_callback;
 						mpp.appendChild(subm);
 						mpp2.appendChild(subm2);
 						mpp3.appendChild(subm3);

--- a/src/chrome/content/mzcw-customcolumns.js
+++ b/src/chrome/content/mzcw-customcolumns.js
@@ -1,12 +1,16 @@
 "use strict";
-// var EXPORTED_SYMBOLS = ["miczColumnsWizard_CustCols"];
+
+var EXPORTED_SYMBOLS = ["miczColumnsWizard_CustCols"];
+
+// Check
+// const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 ChromeUtils.import("chrome://columnswizard/content/mzcw-prefsutils.jsm");
 
 var miczColumnsWizard_CustCols = {
 
 	// Bundled Custom Columns
 	CustColDefaultIndex: ["cc", "bcc", "replyto", "xoriginalfrom", "contentbase", "xspamscore"],
-	CreateDbObserver: new Array(),
+	CreateDbObserver: [],
 
 	addCustomColumnHandler: function (coltype) {
 		if (gDBView !== null) {
@@ -15,8 +19,7 @@ var miczColumnsWizard_CustCols = {
 	},
 
 	addCustomColumn: function (elementc, ObserverService) {
-		let strBundleCW = Components.classes["@mozilla.org/intl/stringbundle;1"].getService(Components.interfaces.nsIStringBundleService);
-		let _bundleCW = strBundleCW.createBundle("chrome://columnswizard/locale/overlay.properties");
+		let _bundleCW = Services.strings.createBundle("chrome://columnswizard/locale/overlay.properties");
 
 		let coltype = elementc.index;
 
@@ -41,7 +44,7 @@ var miczColumnsWizard_CustCols = {
 		cwCol.setAttribute("label", labelString);
 
 		if ((elementc.labelImagePath) && (elementc.labelImagePath !== "")) {	// we have an image to use!!
-			let file = Components.classes["@mozilla.org/file/local;1"].createInstance(Components.interfaces.nsIFile);
+			let file = Cc["@mozilla.org/file/local;1"].createInstance(Ci.nsIFile);
 			file.initWithPath(elementc.labelImagePath);
 			if ((file) && (file.exists())) {
 				cwCol.setAttribute("src", "file://" + elementc.labelImagePath);
@@ -70,8 +73,7 @@ var miczColumnsWizard_CustCols = {
 	},
 
 	updateCustomColumn: function (elementc) {
-		let strBundleCW = Components.classes["@mozilla.org/intl/stringbundle;1"].getService(Components.interfaces.nsIStringBundleService);
-		let _bundleCW = strBundleCW.createBundle("chrome://columnswizard/locale/overlay.properties");
+		let _bundleCW = Services.strings.createBundle("chrome://columnswizard/locale/overlay.properties");
 
 		let coltype = elementc.index;
 		let cwCol = document.getElementById(coltype + "Col_cw");
@@ -107,12 +109,12 @@ var miczColumnsWizard_CustCols = {
 	},
 
 	loadCustCols: function () {
-		/* let prefsc = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
+		/* let prefsc = Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefService);
 		let prefs = prefsc.getBranch("extensions.ColumnsWizard.CustCols.");
 		let prefs_def = prefsc.getBranch("extensions.ColumnsWizard.CustCols.def.");*/
 		// let CustColIndexStr=prefs.getCharPref("index");
 		let CustColIndexStr = miczColumnsWizardPrefsUtils.getCustColsIndex();
-		let CustColIndex = new Array();
+		let CustColIndex = [];
 		if (CustColIndexStr === '') {
 			// Set default CustColIndex
 			CustColIndex = miczColumnsWizard_CustCols.CustColDefaultIndex;
@@ -121,7 +123,7 @@ var miczColumnsWizard_CustCols = {
 		} else {
 			CustColIndex = miczColumnsWizard_CustCols.checkCustColDefaultIndex(JSON.parse(CustColIndexStr));
 		}
-		let loadedCustColPref = new Array();
+		let loadedCustColPref = [];
 		// dump(">>>>>>>>>>>>> miczColumnsWizard: [miczColumnsWizard_CustCols] CustColIndex: "+JSON.stringify(CustColIndex)+"\r\n");
 		miczColumnsWizard_CustCols.checkDefaultCustomColumnPrefs();
 		for (let singlecolidx in CustColIndex) {
@@ -151,7 +153,7 @@ var miczColumnsWizard_CustCols = {
 	},
 
 	checkDefaultCustomColumnPrefs: function () {
-		/* let prefsc = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
+		/* let prefsc = Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefService);
 		let prefs = prefsc.getBranch("extensions.ColumnsWizard.CustCols.");
 		let prefs_def = prefsc.getBranch("extensions.ColumnsWizard.CustCols.def.");*/
 
@@ -221,24 +223,24 @@ var miczColumnsWizard_CustCols = {
 	},
 
 	addNewCustCol: function (newcol) {
-		let ObserverService = Components.classes["@mozilla.org/observer-service;1"].getService(Components.interfaces.nsIObserverService);
+		let ObserverService = Cc["@mozilla.org/observer-service;1"].getService(Ci.nsIObserverService);
 		miczColumnsWizard_CustCols.addCustColIndex(newcol.index);
 		ObserverService.notifyObservers(null, "CW-newCustomColumn", JSON.stringify(newcol));
 		miczColumnsWizard_CustCols.saveCustCol(newcol);
 	},
 
 	updateCustCol: function (newcol) {
-		let ObserverService = Components.classes["@mozilla.org/observer-service;1"].getService(Components.interfaces.nsIObserverService);
+		let ObserverService = Cc["@mozilla.org/observer-service;1"].getService(Ci.nsIObserverService);
 		ObserverService.notifyObservers(null, "CW-updateCustomColumn", JSON.stringify(newcol));
 		miczColumnsWizard_CustCols.saveCustCol(newcol);
 	},
 
 	addCustColIndex: function (index) {
-		/* let prefsc = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
+		/* let prefsc = Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefService);
 		let prefs = prefsc.getBranch("extensions.ColumnsWizard.CustCols.");*/
 		// let CustColIndexStr=prefs.getCharPref("index");
 		let CustColIndexStr = miczColumnsWizardPrefsUtils.getCustColsIndex();
-		let CustColIndex = new Array();
+		let CustColIndex = [];
 		if (CustColIndexStr === '') {
 			// Set default CustColIndex
 			CustColIndex = miczColumnsWizard_CustCols.CustColDefaultIndex;
@@ -256,11 +258,11 @@ var miczColumnsWizard_CustCols = {
 	},
 
 	removeCustColIndex: function (index) {
-		/* let prefsc = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
+		/* let prefsc = Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefService);
 		let prefs = prefsc.getBranch("extensions.ColumnsWizard.CustCols.");*/
 		// let CustColIndexStr=prefs.getCharPref("index");
 		let CustColIndexStr = miczColumnsWizardPrefsUtils.getCustColsIndex();
-		let CustColIndex = new Array();
+		let CustColIndex = [];
 		if (CustColIndexStr === '') {
 			return;
 		}
@@ -279,7 +281,7 @@ var miczColumnsWizard_CustCols = {
 
 	saveCustCol: function (currcol) {
 		let value = JSON.stringify(currcol);
-		// let prefsc = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
+		// let prefsc = Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefService);
 		// Saving custom columns item to prefs
 		// let prefs_def = prefsc.getBranch("extensions.ColumnsWizard.CustCols.def.");
 		// prefs_def.setCharPref(currcol.index,value);
@@ -307,7 +309,7 @@ var miczColumnsWizard_CustCols = {
 		}
 
 		// update header editing menu
-		let ObserverService = Components.classes["@mozilla.org/observer-service;1"].getService(Components.interfaces.nsIObserverService);
+		let ObserverService = Cc["@mozilla.org/observer-service;1"].getService(Ci.nsIObserverService);
 		ObserverService.notifyObservers(null, "CW-updateHeaderEditingMenu", null);
 
 		return value;
@@ -316,17 +318,17 @@ var miczColumnsWizard_CustCols = {
 	deleteCustCol: function (col_idx) {
 		miczColumnsWizard_CustCols.removeCustColIndex(col_idx);
 		// update header editing menu
-		let ObserverService = Components.classes["@mozilla.org/observer-service;1"].getService(Components.interfaces.nsIObserverService);
+		let ObserverService = Cc["@mozilla.org/observer-service;1"].getService(Ci.nsIObserverService);
 		ObserverService.notifyObservers(null, "CW-updateHeaderEditingMenu", null);
 	},
 
 	activateCustomHeaderSearchable: function (newHeader) {
 		// dump(">>>>>>>>>>>>> miczColumnsWizard: [CustomHeaderSearchable] "+newHeader+"\r\n");
-		// let prefService = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefBranch);
+		// let prefService = Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefBranch);
 		// let currentHeaders = prefService.getCharPref("mailnews.customHeaders");
 		let currentHeaders = miczColumnsWizardPrefsUtils.getCharPref("mailnews.customHeaders");
 		// dump(">>>>>>>>>>>>> miczColumnsWizard: [CustomHeaderSearchable]: currentHeaders: "+currentHeaders+"\r\n");
-		let headers_array = new Array();
+		let headers_array = [];
 		if (currentHeaders !== '') {
 			headers_array = currentHeaders.split(': ');
 		}
@@ -342,7 +344,7 @@ var miczColumnsWizard_CustCols = {
 
 	deactivateCustomHeaderSearchable: function (newHeader) {
 		// dump(">>>>>>>>>>>>> miczColumnsWizard: [deactivate CustomHeaderSearchable] "+newHeader+"\r\n");
-		// let prefService = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefBranch);
+		// let prefService = Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefBranch);
 		// let {Services}=ChromeUtils.import("resource://gre/modules/Services.jsm");
 		// let currentHeaders = Services.prefs.getCharPref("mailnews.customHeaders");
 		// let currentHeaders = prefService.getCharPref("mailnews.customHeaders");
@@ -359,14 +361,14 @@ var miczColumnsWizard_CustCols = {
 	},
 
 	addCustColIndexMod: function (index) {
-		// let prefsc = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
+		// let prefsc = Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefService);
 		// let prefs = prefsc.getBranch("extensions.ColumnsWizard.CustCols.");
 		let CustColIndexStr = '';
 		try {
 			// CustColIndexStr=prefs.getCharPref("index_mod");
 			CustColIndexStr = miczColumnsWizardPrefsUtils.getCustColsIndexMod();
 		} catch (e) { }
-		let CustColIndex = new Array();
+		let CustColIndex = [];
 		if (CustColIndexStr !== '') {
 			CustColIndex = JSON.parse(CustColIndexStr);
 		}
@@ -380,11 +382,11 @@ var miczColumnsWizard_CustCols = {
 	},
 
 	removeCustColIndexMod: function (index) {
-		// let prefsc = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
+		// let prefsc = Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefService);
 		// let prefs = prefsc.getBranch("extensions.ColumnsWizard.CustCols.");
 		// let CustColIndexStr=prefs.getCharPref("index_mod");
 		let CustColIndexStr = miczColumnsWizardPrefsUtils.getCustColsIndexMod();
-		let CustColIndex = new Array();
+		let CustColIndex = [];
 		if (CustColIndexStr === '') {
 			return;
 		}

--- a/src/chrome/content/mzcw-customcolumns.js
+++ b/src/chrome/content/mzcw-customcolumns.js
@@ -1,378 +1,377 @@
 "use strict";
-//var EXPORTED_SYMBOLS = ["miczColumnsWizard_CustCols"];
+// var EXPORTED_SYMBOLS = ["miczColumnsWizard_CustCols"];
 ChromeUtils.import("chrome://columnswizard/content/mzcw-prefsutils.jsm");
 
-var miczColumnsWizard_CustCols={
+var miczColumnsWizard_CustCols = {
 
-  //Bundled Custom Columns
-  CustColDefaultIndex:["cc","bcc","replyto","xoriginalfrom","contentbase","xspamscore"],
-  CreateDbObserver:new Array(),
+	// Bundled Custom Columns
+	CustColDefaultIndex: ["cc", "bcc", "replyto", "xoriginalfrom", "contentbase", "xspamscore"],
+	CreateDbObserver: new Array(),
 
-  addCustomColumnHandler: function(coltype){
-	if(gDBView!=null){
-    	gDBView.addColumnHandler(coltype+"Col_cw", miczColumnsWizard_CustCols["columnHandler_"+coltype]);
- 	}
-  },
-
-  addCustomColumn: function(elementc,ObserverService){
-    let strBundleCW = Components.classes["@mozilla.org/intl/stringbundle;1"].getService(Components.interfaces.nsIStringBundleService);
-    let _bundleCW = strBundleCW.createBundle("chrome://columnswizard/locale/overlay.properties");
-
-	let coltype=elementc.index;
-
-    if(document.getElementById(coltype+"Col_cw")){
-      return;
-    }
-
-    let labelString = '';
-    let tooltipString = '';
-    if(elementc.isBundled){
-		labelString = _bundleCW.GetStringFromName("ColumnsWizard"+coltype+".label");
-		tooltipString = _bundleCW.GetStringFromName("ColumnsWizard"+coltype+"Desc.label");
-	}else{
-		labelString = elementc.labelString;
-		tooltipString = elementc.tooltipString;
-	}
-    let cwCol = document.createElement("treecol");
-    cwCol.setAttribute("id",coltype+"Col_cw");
-    cwCol.setAttribute("persist","hidden ordinal width");
-    cwCol.setAttribute("hidden","true");
-    cwCol.setAttribute("flex","4");
-    cwCol.setAttribute("label",labelString);
-
-	if((elementc.labelImagePath)&&(elementc.labelImagePath!="")){	//we have an image to use!!
-		let file = Components.classes["@mozilla.org/file/local;1"].createInstance(Components.interfaces.nsIFile);
-		file.initWithPath(elementc.labelImagePath)
-		if((file)&&(file.exists())){
-			cwCol.setAttribute("src","file://"+elementc.labelImagePath);
-			cwCol.setAttribute("class", "treecol-image cw_col_image");
+	addCustomColumnHandler: function (coltype) {
+		if (gDBView !== null) {
+			gDBView.addColumnHandler(coltype + "Col_cw", miczColumnsWizard_CustCols["columnHandler_" + coltype]);
 		}
-	}
+	},
 
-    cwCol.setAttribute("tooltiptext",tooltipString);
-    let cwSplitter = document.createElement("splitter");
-    cwSplitter.setAttribute("class","tree-splitter");
-    cwSplitter.setAttribute("resizeafter","farthest");
-    let element = document.getElementById("threadCols");
-    let lastordinal=element.children.length;
-    //dump('>>>>>>>>> columns [js children: '+lastordinal+"] [real: "+(lastordinal-1)/2+"]\r\n");
-    let cwSplitterOrdinal=(lastordinal % 2)==0?lastordinal+2:lastordinal+1;
-    let cwColOrdinal=cwSplitterOrdinal+1;
-    cwSplitter.setAttribute("ordinal",cwSplitterOrdinal);
-    cwCol.setAttribute("ordinal",cwColOrdinal);
-    element.appendChild(cwSplitter);
-    element.appendChild(cwCol);
+	addCustomColumn: function (elementc, ObserverService) {
+		let strBundleCW = Components.classes["@mozilla.org/intl/stringbundle;1"].getService(Components.interfaces.nsIStringBundleService);
+		let _bundleCW = strBundleCW.createBundle("chrome://columnswizard/locale/overlay.properties");
 
-    //dump(">>>>>>>>>>>>> miczColumnsWizard->addCustomColumn: [coltype] "+coltype+"\r\n");
-    //DbObserver Managing
-    miczColumnsWizard_CustCols.addCustomColumnHandler(coltype);
-   	ObserverService.addObserver(miczColumnsWizard_CustCols.CreateDbObserver[coltype], "MsgCreateDBView", false);
-  },
+		let coltype = elementc.index;
 
-  updateCustomColumn: function(elementc){
-    let strBundleCW = Components.classes["@mozilla.org/intl/stringbundle;1"].getService(Components.interfaces.nsIStringBundleService);
-    let _bundleCW = strBundleCW.createBundle("chrome://columnswizard/locale/overlay.properties");
+		if (document.getElementById(coltype + "Col_cw")) {
+			return;
+		}
 
-	let coltype=elementc.index;
-	let cwCol=document.getElementById(coltype+"Col_cw")
+		let labelString = '';
+		let tooltipString = '';
+		if (elementc.isBundled) {
+			labelString = _bundleCW.GetStringFromName("ColumnsWizard" + coltype + ".label");
+			tooltipString = _bundleCW.GetStringFromName("ColumnsWizard" + coltype + "Desc.label");
+		} else {
+			labelString = elementc.labelString;
+			tooltipString = elementc.tooltipString;
+		}
+		let cwCol = document.createElement("treecol");
+		cwCol.setAttribute("id", coltype + "Col_cw");
+		cwCol.setAttribute("persist", "hidden ordinal width");
+		cwCol.setAttribute("hidden", "true");
+		cwCol.setAttribute("flex", "4");
+		cwCol.setAttribute("label", labelString);
 
-    if(!cwCol){
-      return;
-    }
-
-    let labelString = '';
-    let tooltipString = '';
-    if(elementc.isBundled){
-		labelString = _bundleCW.GetStringFromName("ColumnsWizard"+coltype+".label");
-		tooltipString = _bundleCW.GetStringFromName("ColumnsWizard"+coltype+"Desc.label");
-	}else{
-		labelString = elementc.labelString;
-		tooltipString = elementc.tooltipString;
-	}
-    cwCol.setAttribute("label",labelString);
-    cwCol.setAttribute("tooltiptext",tooltipString);
-  },
-
-    removeCustomColumn: function(coltype,ObserverService){
-      let element = document.getElementById(coltype+"Col_cw");
-      if(element) element.parentNode.removeChild(element);
-
-      //dump(">>>>>>>>>>>>> miczColumnsWizard->removeCustomColumn: [coltype] "+coltype+"\r\n");
-      //DbObserver Managing
-      try{
-      	ObserverService.removeObserver(miczColumnsWizard_CustCols.CreateDbObserver[coltype], "MsgCreateDBView");
-      }catch(ex){
-		//No observer found
-	  }
-    },
-
-   loadCustCols:function(){
-    /*let prefsc = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
-    let prefs = prefsc.getBranch("extensions.ColumnsWizard.CustCols.");
-    let prefs_def = prefsc.getBranch("extensions.ColumnsWizard.CustCols.def.");*/
-    //let CustColIndexStr=prefs.getCharPref("index");
-    let CustColIndexStr=miczColumnsWizardPrefsUtils.getCustColsIndex();
-    let CustColIndex=new Array();
-    if(CustColIndexStr==''){
-		//Set default CustColIndex
-		CustColIndex=miczColumnsWizard_CustCols.CustColDefaultIndex;
-		//prefs.setCharPref("index",JSON.stringify(CustColIndex));
-		miczColumnsWizardPrefsUtils.setCustColsIndex(JSON.stringify(CustColIndex));
-	}else{
-		CustColIndex=miczColumnsWizard_CustCols.checkCustColDefaultIndex(JSON.parse(CustColIndexStr));
-	}
-    let loadedCustColPref=new Array();
-	//dump(">>>>>>>>>>>>> miczColumnsWizard: [miczColumnsWizard_CustCols] CustColIndex: "+JSON.stringify(CustColIndex)+"\r\n");
-    miczColumnsWizard_CustCols.checkDefaultCustomColumnPrefs();
-    for (let singlecolidx in CustColIndex) {
-		//dump(">>>>>>>>>>>>> miczColumnsWizard->loadCustCols: [CustColIndex[singlecolidx]] "+CustColIndex[singlecolidx]+"\r\n");
-		try{
-			loadedCustColPref[CustColIndex[singlecolidx]]=JSON.parse(miczColumnsWizardPrefsUtils.getCustColDef(CustColIndex[singlecolidx]));
-			if(loadedCustColPref[CustColIndex[singlecolidx]].isSearchable===undefined){
-				loadedCustColPref[CustColIndex[singlecolidx]].isSearchable=false;
+		if ((elementc.labelImagePath) && (elementc.labelImagePath !== "")) {	// we have an image to use!!
+			let file = Components.classes["@mozilla.org/file/local;1"].createInstance(Components.interfaces.nsIFile);
+			file.initWithPath(elementc.labelImagePath);
+			if ((file) && (file.exists())) {
+				cwCol.setAttribute("src", "file://" + elementc.labelImagePath);
+				cwCol.setAttribute("class", "treecol-image cw_col_image");
 			}
-		}catch(ex){
-			//We have an index, but no preference for it, so we remove it...
-			miczColumnsWizard_CustCols.removeCustColIndex(CustColIndex[singlecolidx]);
 		}
-	}
-	//dump(">>>>>>>>>>>>> miczColumnsWizard: [miczColumnsWizard_CustCols] loadedCustColPref: "+JSON.stringify(loadedCustColPref)+"\r\n");
-    return loadedCustColPref;
-  },
 
-  checkCustColDefaultIndex:function(curr_idx){
-		for (let idx in miczColumnsWizard_CustCols.CustColDefaultIndex){
-			if(curr_idx.indexOf(miczColumnsWizard_CustCols.CustColDefaultIndex[idx])==-1){
+		cwCol.setAttribute("tooltiptext", tooltipString);
+		let cwSplitter = document.createElement("splitter");
+		cwSplitter.setAttribute("class", "tree-splitter");
+		cwSplitter.setAttribute("resizeafter", "farthest");
+		let element = document.getElementById("threadCols");
+		let lastordinal = element.children.length;
+		// dump('>>>>>>>>> columns [js children: '+lastordinal+"] [real: "+(lastordinal-1)/2+"]\r\n");
+		let cwSplitterOrdinal = (lastordinal % 2) === 0 ? lastordinal + 2 : lastordinal + 1;
+		let cwColOrdinal = cwSplitterOrdinal + 1;
+		cwSplitter.setAttribute("ordinal", cwSplitterOrdinal);
+		cwCol.setAttribute("ordinal", cwColOrdinal);
+		element.appendChild(cwSplitter);
+		element.appendChild(cwCol);
+
+		// dump(">>>>>>>>>>>>> miczColumnsWizard->addCustomColumn: [coltype] "+coltype+"\r\n");
+		// DbObserver Managing
+		miczColumnsWizard_CustCols.addCustomColumnHandler(coltype);
+		ObserverService.addObserver(miczColumnsWizard_CustCols.CreateDbObserver[coltype], "MsgCreateDBView", false);
+	},
+
+	updateCustomColumn: function (elementc) {
+		let strBundleCW = Components.classes["@mozilla.org/intl/stringbundle;1"].getService(Components.interfaces.nsIStringBundleService);
+		let _bundleCW = strBundleCW.createBundle("chrome://columnswizard/locale/overlay.properties");
+
+		let coltype = elementc.index;
+		let cwCol = document.getElementById(coltype + "Col_cw");
+
+		if (!cwCol) {
+			return;
+		}
+
+		let labelString = '';
+		let tooltipString = '';
+		if (elementc.isBundled) {
+			labelString = _bundleCW.GetStringFromName("ColumnsWizard" + coltype + ".label");
+			tooltipString = _bundleCW.GetStringFromName("ColumnsWizard" + coltype + "Desc.label");
+		} else {
+			labelString = elementc.labelString;
+			tooltipString = elementc.tooltipString;
+		}
+		cwCol.setAttribute("label", labelString);
+		cwCol.setAttribute("tooltiptext", tooltipString);
+	},
+
+	removeCustomColumn: function (coltype, ObserverService) {
+		let element = document.getElementById(coltype + "Col_cw");
+		if (element) element.parentNode.removeChild(element);
+
+		// dump(">>>>>>>>>>>>> miczColumnsWizard->removeCustomColumn: [coltype] "+coltype+"\r\n");
+		// DbObserver Managing
+		try {
+			ObserverService.removeObserver(miczColumnsWizard_CustCols.CreateDbObserver[coltype], "MsgCreateDBView");
+		} catch (ex) {
+			// No observer found
+		}
+	},
+
+	loadCustCols: function () {
+		/* let prefsc = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
+		let prefs = prefsc.getBranch("extensions.ColumnsWizard.CustCols.");
+		let prefs_def = prefsc.getBranch("extensions.ColumnsWizard.CustCols.def.");*/
+		// let CustColIndexStr=prefs.getCharPref("index");
+		let CustColIndexStr = miczColumnsWizardPrefsUtils.getCustColsIndex();
+		let CustColIndex = new Array();
+		if (CustColIndexStr === '') {
+			// Set default CustColIndex
+			CustColIndex = miczColumnsWizard_CustCols.CustColDefaultIndex;
+			// prefs.setCharPref("index",JSON.stringify(CustColIndex));
+			miczColumnsWizardPrefsUtils.setCustColsIndex(JSON.stringify(CustColIndex));
+		} else {
+			CustColIndex = miczColumnsWizard_CustCols.checkCustColDefaultIndex(JSON.parse(CustColIndexStr));
+		}
+		let loadedCustColPref = new Array();
+		// dump(">>>>>>>>>>>>> miczColumnsWizard: [miczColumnsWizard_CustCols] CustColIndex: "+JSON.stringify(CustColIndex)+"\r\n");
+		miczColumnsWizard_CustCols.checkDefaultCustomColumnPrefs();
+		for (let singlecolidx in CustColIndex) {
+			// dump(">>>>>>>>>>>>> miczColumnsWizard->loadCustCols: [CustColIndex[singlecolidx]] "+CustColIndex[singlecolidx]+"\r\n");
+			try {
+				loadedCustColPref[CustColIndex[singlecolidx]] = JSON.parse(miczColumnsWizardPrefsUtils.getCustColDef(CustColIndex[singlecolidx]));
+				if (loadedCustColPref[CustColIndex[singlecolidx]].isSearchable === undefined) {
+					loadedCustColPref[CustColIndex[singlecolidx]].isSearchable = false;
+				}
+			} catch (ex) {
+				// We have an index, but no preference for it, so we remove it...
+				miczColumnsWizard_CustCols.removeCustColIndex(CustColIndex[singlecolidx]);
+			}
+		}
+		// dump(">>>>>>>>>>>>> miczColumnsWizard: [miczColumnsWizard_CustCols] loadedCustColPref: "+JSON.stringify(loadedCustColPref)+"\r\n");
+		return loadedCustColPref;
+	},
+
+	checkCustColDefaultIndex: function (curr_idx) {
+		for (let idx in miczColumnsWizard_CustCols.CustColDefaultIndex) {
+			if (curr_idx.indexOf(miczColumnsWizard_CustCols.CustColDefaultIndex[idx]) === -1) {
 				curr_idx.push(miczColumnsWizard_CustCols.CustColDefaultIndex[idx]);
 			}
 		}
-		//dump(">>>>>>>>>>>>> miczColumnsWizard->checkCustColDefaultIndex: curr_idx "+JSON.stringify(curr_idx)+"\r\n");
+		// dump(">>>>>>>>>>>>> miczColumnsWizard->checkCustColDefaultIndex: curr_idx "+JSON.stringify(curr_idx)+"\r\n");
 		return curr_idx;
-  },
+	},
 
-  checkDefaultCustomColumnPrefs: function(){
-		/*let prefsc = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
+	checkDefaultCustomColumnPrefs: function () {
+		/* let prefsc = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
 		let prefs = prefsc.getBranch("extensions.ColumnsWizard.CustCols.");
 		let prefs_def = prefsc.getBranch("extensions.ColumnsWizard.CustCols.def.");*/
 
 		for (let singlecolidx in miczColumnsWizard_CustCols.CustColDefaultIndex) {
-			//dump(">>>>>>>>>>>>> miczColumnsWizard: [checkDefaultCustomColumnPrefs singlecolidx] "+miczColumnsWizard_CustCols.CustColDefaultIndex[singlecolidx]+" \r\n");
-			let currcol=miczColumnsWizardPrefsUtils.getCustColDef(miczColumnsWizard_CustCols.CustColDefaultIndex[singlecolidx]);
-			if(currcol==''){//Default custom column pref not present
-				let dcurrcol={}
-				switch(miczColumnsWizard_CustCols.CustColDefaultIndex[singlecolidx]){
+			// dump(">>>>>>>>>>>>> miczColumnsWizard: [checkDefaultCustomColumnPrefs singlecolidx] "+miczColumnsWizard_CustCols.CustColDefaultIndex[singlecolidx]+" \r\n");
+			let currcol = miczColumnsWizardPrefsUtils.getCustColDef(miczColumnsWizard_CustCols.CustColDefaultIndex[singlecolidx]);
+			if (currcol === '') { // Default custom column pref not present
+				let dcurrcol = {};
+				switch (miczColumnsWizard_CustCols.CustColDefaultIndex[singlecolidx]) {
 					case 'cc':
 						dcurrcol.enabled = miczColumnsWizardPrefsUtils.getCustColBool("AddCc");
 						dcurrcol.def = "AddCc";
 						dcurrcol.dbHeader = "ccList";
-						dcurrcol.sortnumber=false;
-						dcurrcol.isCustom=false;
-						dcurrcol.isSearchable=false;
+						dcurrcol.sortnumber = false;
+						dcurrcol.isCustom = false;
+						dcurrcol.isSearchable = false;
 						break;
 					case 'bcc':
 						dcurrcol.enabled = miczColumnsWizardPrefsUtils.getCustColBool("Addbcc");
 						dcurrcol.def = "Addbcc";
 						dcurrcol.dbHeader = "bccList";
-						dcurrcol.sortnumber=false;
-						dcurrcol.isCustom=false;
-						dcurrcol.isSearchable=false;
+						dcurrcol.sortnumber = false;
+						dcurrcol.isCustom = false;
+						dcurrcol.isSearchable = false;
 						break;
 					case 'replyto':
 						dcurrcol.enabled = miczColumnsWizardPrefsUtils.getCustColBool("Addreplyto");
 						dcurrcol.def = "Addreplyto";
 						dcurrcol.dbHeader = "replyTo";
-						dcurrcol.sortnumber=false;
-						dcurrcol.isCustom=false;
-						dcurrcol.isSearchable=true;
+						dcurrcol.sortnumber = false;
+						dcurrcol.isCustom = false;
+						dcurrcol.isSearchable = true;
 						break;
 					case 'xoriginalfrom':
 						dcurrcol.enabled = miczColumnsWizardPrefsUtils.getCustColBool("Addxoriginalfrom");
 						dcurrcol.def = "Addxoriginalfrom";
 						dcurrcol.dbHeader = "x-original-from";
-						dcurrcol.sortnumber=false;
-						dcurrcol.isCustom=true;
-						dcurrcol.isSearchable=true;
+						dcurrcol.sortnumber = false;
+						dcurrcol.isCustom = true;
+						dcurrcol.isSearchable = true;
 						break;
 					case 'contentbase':
 						dcurrcol.enabled = miczColumnsWizardPrefsUtils.getCustColBool("Addcontentbase");
 						dcurrcol.def = "Addcontentbase";
 						dcurrcol.dbHeader = "content-base";
-						dcurrcol.sortnumber=false;
-						dcurrcol.isCustom=true;
-						dcurrcol.isSearchable=true;
+						dcurrcol.sortnumber = false;
+						dcurrcol.isCustom = true;
+						dcurrcol.isSearchable = true;
 						break;
 					case 'xspamscore':
 						dcurrcol.enabled = false;
 						dcurrcol.def = "";
 						dcurrcol.dbHeader = "x-spam-score";
-						dcurrcol.sortnumber=true;
-						dcurrcol.isCustom=true;
-						dcurrcol.isSearchable=true;
+						dcurrcol.sortnumber = true;
+						dcurrcol.isCustom = true;
+						dcurrcol.isSearchable = true;
 						break;
 				}
-				dcurrcol.index=miczColumnsWizard_CustCols.CustColDefaultIndex[singlecolidx];
-				dcurrcol.isBundled=true;
-				dcurrcol.labelString='';
-				dcurrcol.tooltipString='';
-				//prefs_def.setCharPref(miczColumnsWizard_CustCols.CustColDefaultIndex[singlecolidx],JSON.stringify(dcurrcol));
-				miczColumnsWizardPrefsUtils.setCustColDef(miczColumnsWizard_CustCols.CustColDefaultIndex[singlecolidx],JSON.stringify(dcurrcol));
+				dcurrcol.index = miczColumnsWizard_CustCols.CustColDefaultIndex[singlecolidx];
+				dcurrcol.isBundled = true;
+				dcurrcol.labelString = '';
+				dcurrcol.tooltipString = '';
+				// prefs_def.setCharPref(miczColumnsWizard_CustCols.CustColDefaultIndex[singlecolidx],JSON.stringify(dcurrcol));
+				miczColumnsWizardPrefsUtils.setCustColDef(miczColumnsWizard_CustCols.CustColDefaultIndex[singlecolidx], JSON.stringify(dcurrcol));
 			}
 		}
 	},
 
-	addNewCustCol:function(newcol){
+	addNewCustCol: function (newcol) {
 		let ObserverService = Components.classes["@mozilla.org/observer-service;1"].getService(Components.interfaces.nsIObserverService);
 		miczColumnsWizard_CustCols.addCustColIndex(newcol.index);
-		ObserverService.notifyObservers(null,"CW-newCustomColumn",JSON.stringify(newcol));
+		ObserverService.notifyObservers(null, "CW-newCustomColumn", JSON.stringify(newcol));
 		miczColumnsWizard_CustCols.saveCustCol(newcol);
 	},
 
-	updateCustCol:function(newcol){
+	updateCustCol: function (newcol) {
 		let ObserverService = Components.classes["@mozilla.org/observer-service;1"].getService(Components.interfaces.nsIObserverService);
-		ObserverService.notifyObservers(null,"CW-updateCustomColumn",JSON.stringify(newcol));
+		ObserverService.notifyObservers(null, "CW-updateCustomColumn", JSON.stringify(newcol));
 		miczColumnsWizard_CustCols.saveCustCol(newcol);
 	},
 
-	addCustColIndex:function(index){
-		/*let prefsc = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
+	addCustColIndex: function (index) {
+		/* let prefsc = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
 		let prefs = prefsc.getBranch("extensions.ColumnsWizard.CustCols.");*/
-		//let CustColIndexStr=prefs.getCharPref("index");
-		let CustColIndexStr=miczColumnsWizardPrefsUtils.getCustColsIndex();
-		let CustColIndex=new Array();
-		if(CustColIndexStr==''){
-			//Set default CustColIndex
-			CustColIndex=miczColumnsWizard_CustCols.CustColDefaultIndex;
-			//prefs.setCharPref("index",JSON.stringify(CustColIndex));
+		// let CustColIndexStr=prefs.getCharPref("index");
+		let CustColIndexStr = miczColumnsWizardPrefsUtils.getCustColsIndex();
+		let CustColIndex = new Array();
+		if (CustColIndexStr === '') {
+			// Set default CustColIndex
+			CustColIndex = miczColumnsWizard_CustCols.CustColDefaultIndex;
+			// prefs.setCharPref("index",JSON.stringify(CustColIndex));
 			miczColumnsWizardPrefsUtils.setCustColsIndex(JSON.stringify(CustColIndex));
-		}else{
-			CustColIndex=miczColumnsWizard_CustCols.checkCustColDefaultIndex(JSON.parse(CustColIndexStr));
+		} else {
+			CustColIndex = miczColumnsWizard_CustCols.checkCustColDefaultIndex(JSON.parse(CustColIndexStr));
 		}
-		//Add new element to index and save it
-		if(CustColIndex.indexOf(index)==-1){
+		// Add new element to index and save it
+		if (CustColIndex.indexOf(index) === -1) {
 			CustColIndex.push(index);
 		}
-		//prefs.setCharPref("index",JSON.stringify(CustColIndex));
+		// prefs.setCharPref("index",JSON.stringify(CustColIndex));
 		miczColumnsWizardPrefsUtils.setCustColsIndex(JSON.stringify(CustColIndex));
 	},
 
-	removeCustColIndex:function(index){
-		/*let prefsc = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
+	removeCustColIndex: function (index) {
+		/* let prefsc = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
 		let prefs = prefsc.getBranch("extensions.ColumnsWizard.CustCols.");*/
-		//let CustColIndexStr=prefs.getCharPref("index");
-		let CustColIndexStr=miczColumnsWizardPrefsUtils.getCustColsIndex();
-		let CustColIndex=new Array();
-		if(CustColIndexStr==''){
+		// let CustColIndexStr=prefs.getCharPref("index");
+		let CustColIndexStr = miczColumnsWizardPrefsUtils.getCustColsIndex();
+		let CustColIndex = new Array();
+		if (CustColIndexStr === '') {
 			return;
-		}else{
-			CustColIndex=JSON.parse(CustColIndexStr);
 		}
-		//Remove the element to index and save it
-		let el_idx=CustColIndex.indexOf(index);
-		if(el_idx>-1){
-			CustColIndex.splice(el_idx,1);
+		CustColIndex = JSON.parse(CustColIndexStr);
+
+		// Remove the element to index and save it
+		let el_idx = CustColIndex.indexOf(index);
+		if (el_idx > -1) {
+			CustColIndex.splice(el_idx, 1);
 		}
-		//prefs.setCharPref("index",JSON.stringify(CustColIndex));
+		// prefs.setCharPref("index",JSON.stringify(CustColIndex));
 		miczColumnsWizardPrefsUtils.setCustColsIndex(JSON.stringify(CustColIndex));
-		//remove it also from index_mod
+		// remove it also from index_mod
 		miczColumnsWizard_CustCols.removeCustColIndexMod(index);
 	},
 
-	saveCustCol: function(currcol) {
+	saveCustCol: function (currcol) {
 		let value = JSON.stringify(currcol);
-		//let prefsc = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
-		//Saving custom columns item to prefs
-		//let prefs_def = prefsc.getBranch("extensions.ColumnsWizard.CustCols.def.");
-		//prefs_def.setCharPref(currcol.index,value);
-		miczColumnsWizardPrefsUtils.setCustColDef(currcol.index,value);
+		// let prefsc = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
+		// Saving custom columns item to prefs
+		// let prefs_def = prefsc.getBranch("extensions.ColumnsWizard.CustCols.def.");
+		// prefs_def.setCharPref(currcol.index,value);
+		miczColumnsWizardPrefsUtils.setCustColDef(currcol.index, value);
 
-		//Saving enabled status to prefs (for bundled custom columns)
-		if((currcol.isBundled)&&(currcol.def !== undefined)&&(currcol.def != "")){
-			//let prefs=prefsc.getBranch("extensions.ColumnsWizard.CustCols.");
-			//prefs.setBoolPref(currcol.def,currcol.enabled);
-			miczColumnsWizardPrefsUtils.setCustColBool(currcol.index,value);
+		// Saving enabled status to prefs (for bundled custom columns)
+		if ((currcol.isBundled) && (currcol.def !== undefined) && (currcol.def !== "")) {
+			// let prefs=prefsc.getBranch("extensions.ColumnsWizard.CustCols.");
+			// prefs.setBoolPref(currcol.def,currcol.enabled);
+			miczColumnsWizardPrefsUtils.setCustColBool(currcol.index, value);
 		}
 
-		//Adding the cust col as searchable
-		if(currcol.isSearchable){
+		// Adding the cust col as searchable
+		if (currcol.isSearchable) {
 			miczColumnsWizard_CustCols.activateCustomHeaderSearchable(currcol.dbHeader);
-		}else{
+		} else {
 			miczColumnsWizard_CustCols.deactivateCustomHeaderSearchable(currcol.dbHeader);
 		}
 
-		//mod index
-		if(currcol.isEditable){
+		// mod index
+		if (currcol.isEditable) {
 			miczColumnsWizard_CustCols.addCustColIndexMod(currcol.index);
-		}else{
+		} else {
 			miczColumnsWizard_CustCols.removeCustColIndexMod(currcol.index);
 		}
 
-		//update header editing menu
+		// update header editing menu
 		let ObserverService = Components.classes["@mozilla.org/observer-service;1"].getService(Components.interfaces.nsIObserverService);
-		ObserverService.notifyObservers(null,"CW-updateHeaderEditingMenu",null);
+		ObserverService.notifyObservers(null, "CW-updateHeaderEditingMenu", null);
 
-    	return value;
+		return value;
 	},
 
-	deleteCustCol: function(col_idx){
+	deleteCustCol: function (col_idx) {
 		miczColumnsWizard_CustCols.removeCustColIndex(col_idx);
-		//update header editing menu
+		// update header editing menu
 		let ObserverService = Components.classes["@mozilla.org/observer-service;1"].getService(Components.interfaces.nsIObserverService);
-		ObserverService.notifyObservers(null,"CW-updateHeaderEditingMenu",null);
+		ObserverService.notifyObservers(null, "CW-updateHeaderEditingMenu", null);
 	},
 
-	activateCustomHeaderSearchable:function(newHeader){
-		//dump(">>>>>>>>>>>>> miczColumnsWizard: [CustomHeaderSearchable] "+newHeader+"\r\n");
-		//let prefService = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefBranch);
-		//let currentHeaders = prefService.getCharPref("mailnews.customHeaders");
+	activateCustomHeaderSearchable: function (newHeader) {
+		// dump(">>>>>>>>>>>>> miczColumnsWizard: [CustomHeaderSearchable] "+newHeader+"\r\n");
+		// let prefService = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefBranch);
+		// let currentHeaders = prefService.getCharPref("mailnews.customHeaders");
 		let currentHeaders = miczColumnsWizardPrefsUtils.getCharPref("mailnews.customHeaders");
-		//dump(">>>>>>>>>>>>> miczColumnsWizard: [CustomHeaderSearchable]: currentHeaders: "+currentHeaders+"\r\n");
-		let headers_array=new Array();
-		if(currentHeaders!=''){
-			headers_array=currentHeaders.split(': ');
+		// dump(">>>>>>>>>>>>> miczColumnsWizard: [CustomHeaderSearchable]: currentHeaders: "+currentHeaders+"\r\n");
+		let headers_array = new Array();
+		if (currentHeaders !== '') {
+			headers_array = currentHeaders.split(': ');
 		}
-		//dump(">>>>>>>>>>>>> miczColumnsWizard: [CustomHeaderSearchable]: headers_array: "+JSON.stringify(headers_array)+"\r\n");
-		if(headers_array.indexOf(newHeader)==-1){
+		// dump(">>>>>>>>>>>>> miczColumnsWizard: [CustomHeaderSearchable]: headers_array: "+JSON.stringify(headers_array)+"\r\n");
+		if (headers_array.indexOf(newHeader) === -1) {
 			headers_array.push(newHeader);
-			currentHeaders=headers_array.join(': ');
-			//prefService.setCharPref("mailnews.customHeaders", currentHeaders.trim());
+			currentHeaders = headers_array.join(': ');
+			// prefService.setCharPref("mailnews.customHeaders", currentHeaders.trim());
 			miczColumnsWizardPrefsUtils.setCharPref("mailnews.customHeaders", currentHeaders.trim());
-			//dump(">>>>>>>>>>>>> miczColumnsWizard: [CustomHeaderSearchable->Updating] "+newHeader+"\r\n");
+			// dump(">>>>>>>>>>>>> miczColumnsWizard: [CustomHeaderSearchable->Updating] "+newHeader+"\r\n");
 		}
 	},
 
-	deactivateCustomHeaderSearchable:function(newHeader){
-		//dump(">>>>>>>>>>>>> miczColumnsWizard: [deactivate CustomHeaderSearchable] "+newHeader+"\r\n");
-		//let prefService = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefBranch);
-		//let {Services}=ChromeUtils.import("resource://gre/modules/Services.jsm");
-		//let currentHeaders = Services.prefs.getCharPref("mailnews.customHeaders");
-		//let currentHeaders = prefService.getCharPref("mailnews.customHeaders");
+	deactivateCustomHeaderSearchable: function (newHeader) {
+		// dump(">>>>>>>>>>>>> miczColumnsWizard: [deactivate CustomHeaderSearchable] "+newHeader+"\r\n");
+		// let prefService = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefBranch);
+		// let {Services}=ChromeUtils.import("resource://gre/modules/Services.jsm");
+		// let currentHeaders = Services.prefs.getCharPref("mailnews.customHeaders");
+		// let currentHeaders = prefService.getCharPref("mailnews.customHeaders");
 		let currentHeaders = miczColumnsWizardPrefsUtils.getCharPref("mailnews.customHeaders");
-		let headers_array=currentHeaders.split(': ');
-		let h_idx=headers_array.indexOf(newHeader);
-		if(h_idx>-1){
-			headers_array.splice(h_idx,1);
-			currentHeaders=headers_array.join(': ');
-			//prefService.setCharPref("mailnews.customHeaders", currentHeaders.trim());
+		let headers_array = currentHeaders.split(': ');
+		let h_idx = headers_array.indexOf(newHeader);
+		if (h_idx > -1) {
+			headers_array.splice(h_idx, 1);
+			currentHeaders = headers_array.join(': ');
+			// prefService.setCharPref("mailnews.customHeaders", currentHeaders.trim());
 			miczColumnsWizardPrefsUtils.setCharPref("mailnews.customHeaders", currentHeaders.trim());
-			//dump(">>>>>>>>>>>>> miczColumnsWizard: [deactivate CustomHeaderSearchable->Updating] "+newHeader+"\r\n");
+			// dump(">>>>>>>>>>>>> miczColumnsWizard: [deactivate CustomHeaderSearchable->Updating] "+newHeader+"\r\n");
 		}
 	},
 
-	addCustColIndexMod:function(index){
-		//let prefsc = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
-		//let prefs = prefsc.getBranch("extensions.ColumnsWizard.CustCols.");
-		let CustColIndexStr='';
-		try{
-			//CustColIndexStr=prefs.getCharPref("index_mod");
-			CustColIndexStr=miczColumnsWizardPrefsUtils.getCustColsIndexMod();
+	addCustColIndexMod: function (index) {
+		// let prefsc = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
+		// let prefs = prefsc.getBranch("extensions.ColumnsWizard.CustCols.");
+		let CustColIndexStr = '';
+		try {
+			// CustColIndexStr=prefs.getCharPref("index_mod");
+			CustColIndexStr = miczColumnsWizardPrefsUtils.getCustColsIndexMod();
+		} catch (e) { }
+		let CustColIndex = new Array();
+		if (CustColIndexStr !== '') {
+			CustColIndex = JSON.parse(CustColIndexStr);
 		}
-		catch(e){}
-		let CustColIndex=new Array();
-		if(CustColIndexStr!=''){
-			CustColIndex=JSON.parse(CustColIndexStr);
-		}
-		//Add new element to index and save it
-		if(CustColIndex.indexOf(index)==-1){
+		// Add new element to index and save it
+		if (CustColIndex.indexOf(index) === -1) {
 			CustColIndex.push(index);
 		}
 		CustColIndex.sort();
@@ -380,25 +379,25 @@ var miczColumnsWizard_CustCols={
 		miczColumnsWizardPrefsUtils.setCustColsModActive(true);
 	},
 
-	removeCustColIndexMod:function(index){
-		//let prefsc = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
-		//let prefs = prefsc.getBranch("extensions.ColumnsWizard.CustCols.");
-		//let CustColIndexStr=prefs.getCharPref("index_mod");
-		let CustColIndexStr=miczColumnsWizardPrefsUtils.getCustColsIndexMod();
-		let CustColIndex=new Array();
-		if(CustColIndexStr==''){
+	removeCustColIndexMod: function (index) {
+		// let prefsc = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
+		// let prefs = prefsc.getBranch("extensions.ColumnsWizard.CustCols.");
+		// let CustColIndexStr=prefs.getCharPref("index_mod");
+		let CustColIndexStr = miczColumnsWizardPrefsUtils.getCustColsIndexMod();
+		let CustColIndex = new Array();
+		if (CustColIndexStr === '') {
 			return;
-		}else{
-			CustColIndex=JSON.parse(CustColIndexStr);
 		}
-		//Remove the element to index and save it
-		let el_idx=CustColIndex.indexOf(index);
-		if(el_idx>-1){
-			CustColIndex.splice(el_idx,1);
+		CustColIndex = JSON.parse(CustColIndexStr);
+
+		// Remove the element to index and save it
+		let el_idx = CustColIndex.indexOf(index);
+		if (el_idx > -1) {
+			CustColIndex.splice(el_idx, 1);
 		}
-		CustColIndexStr=JSON.stringify(CustColIndex).trim();
+		CustColIndexStr = JSON.stringify(CustColIndex).trim();
 		miczColumnsWizardPrefsUtils.setCustColsIndexMod(CustColIndexStr);
-		if(CustColIndex.length==0){ //no mod cust cols? set the option to false
+		if (CustColIndex.length === 0) { // no mod cust cols? set the option to false
 			miczColumnsWizardPrefsUtils.setCustColsModActive(false);
 		}
 	},

--- a/src/chrome/content/mzcw-customcolumns.js
+++ b/src/chrome/content/mzcw-customcolumns.js
@@ -97,7 +97,8 @@ var miczColumnsWizard_CustCols = {
 
 	removeCustomColumn: function (coltype, ObserverService) {
 		let element = document.getElementById(coltype + "Col_cw");
-		if (element) element.parentNode.removeChild(element);
+		// Check
+		if (element) element.remove();
 
 		// dump(">>>>>>>>>>>>> miczColumnsWizard->removeCustomColumn: [coltype] "+coltype+"\r\n");
 		// DbObserver Managing
@@ -144,7 +145,7 @@ var miczColumnsWizard_CustCols = {
 
 	checkCustColDefaultIndex: function (curr_idx) {
 		for (let idx in miczColumnsWizard_CustCols.CustColDefaultIndex) {
-			if (curr_idx.indexOf(miczColumnsWizard_CustCols.CustColDefaultIndex[idx]) === -1) {
+			if ( !curr_idx.includes(miczColumnsWizard_CustCols.CustColDefaultIndex[idx])) {
 				curr_idx.push(miczColumnsWizard_CustCols.CustColDefaultIndex[idx]);
 			}
 		}
@@ -250,7 +251,7 @@ var miczColumnsWizard_CustCols = {
 			CustColIndex = miczColumnsWizard_CustCols.checkCustColDefaultIndex(JSON.parse(CustColIndexStr));
 		}
 		// Add new element to index and save it
-		if (CustColIndex.indexOf(index) === -1) {
+		if (!CustColIndex.includes(index)) {
 			CustColIndex.push(index);
 		}
 		// prefs.setCharPref("index",JSON.stringify(CustColIndex));
@@ -333,7 +334,7 @@ var miczColumnsWizard_CustCols = {
 			headers_array = currentHeaders.split(': ');
 		}
 		// dump(">>>>>>>>>>>>> miczColumnsWizard: [CustomHeaderSearchable]: headers_array: "+JSON.stringify(headers_array)+"\r\n");
-		if (headers_array.indexOf(newHeader) === -1) {
+		if (!headers_array.includes(newHeader)) {
 			headers_array.push(newHeader);
 			currentHeaders = headers_array.join(': ');
 			// prefService.setCharPref("mailnews.customHeaders", currentHeaders.trim());
@@ -373,7 +374,7 @@ var miczColumnsWizard_CustCols = {
 			CustColIndex = JSON.parse(CustColIndexStr);
 		}
 		// Add new element to index and save it
-		if (CustColIndex.indexOf(index) === -1) {
+		if (!CustColIndex.includes(index)) {
 			CustColIndex.push(index);
 		}
 		CustColIndex.sort();

--- a/src/chrome/content/mzcw-defaultcolsgrid.jsm
+++ b/src/chrome/content/mzcw-defaultcolsgrid.jsm
@@ -7,433 +7,411 @@ const colClass = 'cw-col-class';
 
 var miczColumnsWizardPref_DefaultColsGrid = {
 
-	loadedCustCols:{},
+	loadedCustCols: {},
 
-	loadDefaultColRows_Pref:function(){
-		//let prefsc = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
-		//let prefs = prefsc.getBranch("extensions.ColumnsWizard.");
-		//let DefaultColIndexStr=prefs.getCharPref("DefaultColsList");
-		let DefaultColIndexStr=miczColumnsWizardPrefsUtils.getCharPref_CW("DefaultColsList");
-		let loadedDefaultColIndex=new Array();
-		if(DefaultColIndexStr==''){
-			//Set default cols if none set at the moment
-			loadedDefaultColIndex=miczColumnsWizardPref_DefaultColsGrid.getOriginalColIndex();
-			//dump(">>>>>>>>>>>>> miczColumnsWizard: [miczColumnsWizardPref_DefaultColsGrid loadDefaultColRows_Pref] default loaded and saved pref\r\n");
-		}else{
-			loadedDefaultColIndex=JSON.parse(DefaultColIndexStr);
-			//dump(">>>>>>>>>>>>> miczColumnsWizard: [miczColumnsWizardPref_DefaultColsGrid loadDefaultColRows_Pref] pref loaded\r\n");
+	loadDefaultColRows_Pref: function () {
+		// let prefsc = Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefService);
+		// let prefs = prefsc.getBranch("extensions.ColumnsWizard.");
+		// let DefaultColIndexStr=prefs.getCharPref("DefaultColsList");
+		let DefaultColIndexStr = miczColumnsWizardPrefsUtils.getCharPref_CW("DefaultColsList");
+		let loadedDefaultColIndex = [];
+		if (DefaultColIndexStr === '') {
+			// Set default cols if none set at the moment
+			loadedDefaultColIndex = miczColumnsWizardPref_DefaultColsGrid.getOriginalColIndex();
+			// dump(">>>>>>>>>>>>> miczColumnsWizard: [miczColumnsWizardPref_DefaultColsGrid loadDefaultColRows_Pref] default loaded and saved pref\r\n");
+		} else {
+			loadedDefaultColIndex = JSON.parse(DefaultColIndexStr);
+			// dump(">>>>>>>>>>>>> miczColumnsWizard: [miczColumnsWizardPref_DefaultColsGrid loadDefaultColRows_Pref] pref loaded\r\n");
 		}
-		//fix wrong ordina values: columns must have odd ordinal values, because even values are for splitters (used for columns resizing)
-		loadedDefaultColIndex=miczColumnsWizardPref_DefaultColsGrid.fixOrdinalValues(loadedDefaultColIndex);
-		//check if there are new columns to add
-		let baseColumnStates=miczColumnsWizardPref_DefaultColsGrid.getOriginalColIndex();
-		//dump(">>>>>>>>>>>>> miczColumnsWizard: [miczColumnsWizardPref_DefaultColsGrid] baseColumnState "+JSON.stringify(baseColumnStates)+"\r\n");
-		if(Object.keys(baseColumnStates).length!=Object.keys(loadedDefaultColIndex).length){ // if the length are different so check the column to add
-		//dump(">>>>>>>>>>>>> miczColumnsWizard: [miczColumnsWizardPref_DefaultColsGrid loadDefaultColRows_Pref] different lengths\r\n");
+		// fix wrong ordina values: columns must have odd ordinal values, because even values are for splitters (used for columns resizing)
+		loadedDefaultColIndex = miczColumnsWizardPref_DefaultColsGrid.fixOrdinalValues(loadedDefaultColIndex);
+		// check if there are new columns to add
+		let baseColumnStates = miczColumnsWizardPref_DefaultColsGrid.getOriginalColIndex();
+		// dump(">>>>>>>>>>>>> miczColumnsWizard: [miczColumnsWizardPref_DefaultColsGrid] baseColumnState "+JSON.stringify(baseColumnStates)+"\r\n");
+		if (Object.keys(baseColumnStates).length !== Object.keys(loadedDefaultColIndex).length) { // if the length are different so check the column to add
+			// dump(">>>>>>>>>>>>> miczColumnsWizard: [miczColumnsWizardPref_DefaultColsGrid loadDefaultColRows_Pref] different lengths\r\n");
 			for (let key in baseColumnStates) {
-			  if (!loadedDefaultColIndex.hasOwnProperty(key)){
-				loadedDefaultColIndex[key]=baseColumnStates[key];
-				//dump(">>>>>>>>>>>>> miczColumnsWizard: [miczColumnsWizardPref_DefaultColsGrid loadDefaultColRows_Pref] key not found "+key+"\r\n");
-			  }
+				if (!loadedDefaultColIndex.hasOwnProperty(key)) {
+					loadedDefaultColIndex[key] = baseColumnStates[key];
+					// dump(">>>>>>>>>>>>> miczColumnsWizard: [miczColumnsWizardPref_DefaultColsGrid loadDefaultColRows_Pref] key not found "+key+"\r\n");
+				}
 			}
 		}
-		miczColumnsWizardPrefsUtils.setCharPref_CW("DefaultColsList",JSON.stringify(loadedDefaultColIndex));
-		//dump(">>>>>>>>>>>>> miczColumnsWizard: [miczColumnsWizardPref_DefaultColsGrid loadDefaultColRows_Pref] "+JSON.stringify(loadedDefaultColIndex)+"\r\n");
+		miczColumnsWizardPrefsUtils.setCharPref_CW("DefaultColsList", JSON.stringify(loadedDefaultColIndex));
+		// dump(">>>>>>>>>>>>> miczColumnsWizard: [miczColumnsWizardPref_DefaultColsGrid loadDefaultColRows_Pref] "+JSON.stringify(loadedDefaultColIndex)+"\r\n");
 		return loadedDefaultColIndex;
 	},
 
-	fixOrdinalValues:function(columnStates){
-		//dump(">>>>>>>>>>>>> miczColumnsWizard: [miczColumnsWizardPref_DefaultColsGrid fixOrdinalValues start] columnStates: "+JSON.stringify(columnStates)+"\r\n");
-		let last_ordinal=-1;
-		for (let key in columnStates){
-			if((columnStates[key].ordinal==0)||(columnStates[key].ordinal==null)||(columnStates[key].ordinal=='')){
-				if(last_ordinal==-1){
-					columnStates[key].ordinal=1;
-				}else{
-					columnStates[key].ordinal=last_ordinal+2;
+	fixOrdinalValues: function (columnStates) {
+		// dump(">>>>>>>>>>>>> miczColumnsWizard: [miczColumnsWizardPref_DefaultColsGrid fixOrdinalValues start] columnStates: "+JSON.stringify(columnStates)+"\r\n");
+		let last_ordinal = -1;
+		for (let key in columnStates) {
+			if ((columnStates[key].ordinal === 0) || (columnStates[key].ordinal === null) || (columnStates[key].ordinal === '')) {
+				if (last_ordinal === -1) {
+					columnStates[key].ordinal = 1;
+				} else {
+					columnStates[key].ordinal = last_ordinal + 2;
 				}
 			}
-			last_ordinal=columnStates[key].ordinal;
+			last_ordinal = columnStates[key].ordinal;
 		}
-		//dump(">>>>>>>>>>>>> miczColumnsWizard: [miczColumnsWizardPref_DefaultColsGrid fixOrdinalValues end] columnStates: "+JSON.stringify(columnStates)+"\r\n");
+		// dump(">>>>>>>>>>>>> miczColumnsWizard: [miczColumnsWizardPref_DefaultColsGrid fixOrdinalValues end] columnStates: "+JSON.stringify(columnStates)+"\r\n");
 		return columnStates;
 	},
 
-	getOriginalColIndex:function(){
-		var wMediator = Components.classes["@mozilla.org/appshell/window-mediator;1"].getService(Components.interfaces.nsIWindowMediator);
+	getOriginalColIndex: function () {
+		var wMediator = Cc["@mozilla.org/appshell/window-mediator;1"].getService(Ci.nsIWindowMediator);
 		var mainWindow = wMediator.getMostRecentWindow("mail:3pane");
-		//return mainWindow.gFolderDisplay._getDefaultColumnsForCurrentFolder(); //this version doesn't get custom columns
+		// return mainWindow.gFolderDisplay._getDefaultColumnsForCurrentFolder(); //this version doesn't get custom columns
 		return mainWindow.gFolderDisplay.getColumnStates();
 	},
 
-	createDefaultColsGridHeader: function(doc,container) {
+	createDefaultColsGridHeader: function (doc, container) {
 		const XUL = "http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul";
-		let strBundleCW = Components.classes["@mozilla.org/intl/stringbundle;1"].getService(Components.interfaces.nsIStringBundleService);
+		let strBundleCW = Cc["@mozilla.org/intl/stringbundle;1"].getService(Ci.nsIStringBundleService);
 		let _bundleCW = strBundleCW.createBundle("chrome://columnswizard/locale/overlay.properties");
-		//try {
-			if (!container) return;
-			while (container.firstChild) container.removeChild(container.firstChild);
-			let row = doc.createElementNS(XUL, "row"); // header does not have class colClass
-			["show","sort_by", "col_title", "col_flex", "up", "down"].forEach( function(label) {
-				let item = doc.createElementNS(XUL, "label");
-				item.setAttribute('value', label!=" " ? _bundleCW.GetStringFromName("ColumnsWizardNFCols." + label) : "");
-				//item.setAttribute('value', label);
-				if(label=="col_flex")item.setAttribute('hidden',true);
-				if((label=="up")||(label=="down")){
-					item.setAttribute('class','mzcw-grid_hdr_cnt');
-				}
-				row.insertBefore(item, null);
-			} );
-			row.id = container.name+"-header";
-			container.insertBefore(row, null);
-		/*}catch(err) {
+		// try {
+		if (!container) return;
+		while (container.firstChild) container.removeChild(container.firstChild);
+		let row = doc.createElementNS(XUL, "row"); // header does not have class colClass
+		["show", "sort_by", "col_title", "col_flex", "up", "down"].forEach(function (label) {
+			let item = doc.createElementNS(XUL, "label");
+			item.setAttribute('value', label !== " " ? _bundleCW.GetStringFromName("ColumnsWizardNFCols." + label) : "");
+			// item.setAttribute('value', label);
+			if (label === "col_flex") item.setAttribute('hidden', true);
+			if ((label === "up") || (label === "down")) {
+				item.setAttribute('class', 'mzcw-grid_hdr_cnt');
+			}
+			row.insertBefore(item, null);
+		});
+		row.id = container.name + "-header";
+		container.insertBefore(row, null);
+		/* }catch(err) {
 		  dump(">>>>>>>>>>>>> miczColumnsWizard: [settings createDefaultColsGridHeader] "+err+"\r\n");
 		}*/
 	},
 
-	createDefaultColsGridRows: function(doc,container) {
-		let DefColRows=this.loadDefaultColRows_Pref();
-		//Sort the columns, by the ordinal value...
+	createDefaultColsGridRows: function (doc, container) {
+		let DefColRows = this.loadDefaultColRows_Pref();
+		// Sort the columns, by the ordinal value...
 		let sorted_cols = [];
-		for (let cwcol in DefColRows){
-			  let col_ordinal=DefColRows[cwcol].ordinal==0?99:DefColRows[cwcol].ordinal;
-			  sorted_cols.push([cwcol, col_ordinal]);
-		  }
-		sorted_cols.sort(function(a, b) {return a[1] - b[1]})
+		for (let cwcol in DefColRows) {
+			let col_ordinal = DefColRows[cwcol].ordinal === 0 ? 99 : DefColRows[cwcol].ordinal;
+			sorted_cols.push([cwcol, col_ordinal]);
+		}
+		sorted_cols.sort(function (a, b) { return a[1] - b[1]; });
 
-		//dump(">>>>>>>>>>>>> miczColumnsWizard: [createDefaultColsGridRows] sorted_cols "+JSON.stringify(sorted_cols)+"\r\n");
+		// dump(">>>>>>>>>>>>> miczColumnsWizard: [createDefaultColsGridRows] sorted_cols "+JSON.stringify(sorted_cols)+"\r\n");
 		for (let index in sorted_cols) {
-				DefColRows[sorted_cols[index][0]]['currindex']=sorted_cols[index][0];
-				this.createOneDefaultColRow(doc,container,DefColRows[sorted_cols[index][0]]);
+			DefColRows[sorted_cols[index][0]].currindex = sorted_cols[index][0];
+			this.createOneDefaultColRow(doc, container, DefColRows[sorted_cols[index][0]]);
 		}
 	},
 
-	createOneDefaultColRow:function(doc,container,currcol,ref){
+	createOneDefaultColRow: function (doc, container, currcol, ref) {
 		const XUL = "http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul";
-		//try {
-		  if ( !container ) return;
-		  let row = doc.createElementNS(XUL, "row");
-		  row.setAttribute("class", "mzcw-col_grid_rows");
+		// try {
+		if (!container) return;
+		let row = doc.createElementNS(XUL, "row");
+		row.setAttribute("class", "mzcw-col_grid_rows");
 
-		  //we found no valid preference
-		  if(currcol.visible===undefined)return;
+		// we found no valid preference
+		if (currcol.visible === undefined) return;
 
-  		  let col_id=doc.createElementNS(XUL, "label");
-		  col_id.setAttribute("value", currcol.currindex);
-		  col_id.setAttribute("cwcol", 'currindex');
-		  col_id.setAttribute("hidden", 'true');
+		let col_id = doc.createElementNS(XUL, "label");
+		col_id.setAttribute("value", currcol.currindex);
+		col_id.setAttribute("cwcol", 'currindex');
+		col_id.setAttribute("hidden", 'true');
 
-		  let col_enable = doc.createElementNS(XUL, "checkbox");
-		  col_enable.setAttribute("checked", currcol.visible);
-		  col_enable.setAttribute("cwcol", 'visible');
+		let col_enable = doc.createElementNS(XUL, "checkbox");
+		col_enable.setAttribute("checked", currcol.visible);
+		col_enable.setAttribute("cwcol", 'visible');
 
-		  let col_sortby;
-		  if(miczColumnsWizardPref_DefaultColsGrid.getSortType(currcol.currindex)!=-1){//SORT BY only if a standard col. No way to save a customcol for sorting
-			  col_sortby = doc.createElementNS(XUL, "radio");
-			  col_sortby.setAttribute("group", "cw_sortby");
-			  col_sortby.setAttribute("value", currcol.currindex);
-			  col_sortby.setAttribute("cwcol", 'sortby');
-			  col_sortby.setAttribute("type", 'radio');
-			  //if(currcol.sortby===undefined)currcol.sortby=false;
-			  //if(currcol.sortby)col_sortby.setAttribute("selected", true);
-			  //let prefsc = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
-			  //let prefs = prefsc.getBranch("mailnews.");
-			  //let sortcolindex=prefs.getIntPref("default_sort_type");
-			  let sortcolindex=miczColumnsWizardPrefsUtils.getIntPref("mailnews.default_sort_type");
-			  if(sortcolindex==miczColumnsWizardPref_DefaultColsGrid.getSortType(currcol.currindex))col_sortby.setAttribute("selected", true);
-		  }else{
-			  col_sortby = doc.createElementNS(XUL, "label");
-			  //col_sortby.setAttribute("hidden", 'true');
-			  col_sortby.setAttribute("value", ' ');
-		  }
+		let col_sortby;
+		if (miczColumnsWizardPref_DefaultColsGrid.getSortType(currcol.currindex) !== -1) { // SORT BY only if a standard col. No way to save a customcol for sorting
+			col_sortby = doc.createElementNS(XUL, "radio");
+			col_sortby.setAttribute("group", "cw_sortby");
+			col_sortby.setAttribute("value", currcol.currindex);
+			col_sortby.setAttribute("cwcol", 'sortby');
+			col_sortby.setAttribute("type", 'radio');
+			// if(currcol.sortby===undefined)currcol.sortby=false;
+			// if(currcol.sortby)col_sortby.setAttribute("selected", true);
+			// let prefsc = Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefService);
+			// let prefs = prefsc.getBranch("mailnews.");
+			// let sortcolindex=prefs.getIntPref("default_sort_type");
+			let sortcolindex = miczColumnsWizardPrefsUtils.getIntPref("mailnews.default_sort_type");
+			if (sortcolindex === miczColumnsWizardPref_DefaultColsGrid.getSortType(currcol.currindex)) col_sortby.setAttribute("selected", true);
+		} else {
+			col_sortby = doc.createElementNS(XUL, "label");
+			// col_sortby.setAttribute("hidden", 'true');
+			col_sortby.setAttribute("value", ' ');
+		}
 
-		  let col_title=doc.createElementNS(XUL, "label");
-		  col_title.setAttribute("value", this.getColLocalizedString(currcol.currindex));
-		  col_title.setAttribute("cwcol", 'col_title');
+		let col_title = doc.createElementNS(XUL, "label");
+		col_title.setAttribute("value", this.getColLocalizedString(currcol.currindex));
+		col_title.setAttribute("cwcol", 'col_title');
 
-		  let [col_flex] = [
+		let [col_flex] = [
 			// filter, value, size
-			["flex", currcol.flex!==undefined?currcol.flex:0, "10"]].map( function(attributes) {
-			  let element = doc.createElementNS(XUL, "textbox");
-			  let [filter,value,size] = attributes;
-			  element.setAttribute("cwcol",filter);
-			  if(size) element.setAttribute("size", size);
-			  element.setAttribute("value", value);
-			  if(filter=="flex")element.setAttribute('hidden',true);
-			  return element;
-			} );
+			["flex", currcol.flex !== undefined ? currcol.flex : 0, "10"]].map(function (attributes) {
+				let element = doc.createElementNS(XUL, "textbox");
+				let [filter, value, size] = attributes;
+				element.setAttribute("cwcol", filter);
+				if (size) element.setAttribute("size", size);
+				element.setAttribute("value", value);
+				if (filter === "flex") element.setAttribute('hidden', true);
+				return element;
+			});
 
-		  let [up, down] = [
-			['\u2191', function(aEvent) { miczColumnsWizardPref_DefaultColsGrid.upDownCol(row, true); }, ''],
-			['\u2193', function(aEvent) { miczColumnsWizardPref_DefaultColsGrid.upDownCol(row, false); }, ''] ].map( function(attributes) {
-			  let element = doc.createElementNS(XUL, "toolbarbutton");
-			  element.setAttribute("label", attributes[0]);
-			  element.addEventListener("command", attributes[1], false );
-			  if (attributes[2]) element.classList.add(attributes[2]);
-			  return element;
-			} );
+		let [up, down] = [
+			['\u2191', function (aEvent) { miczColumnsWizardPref_DefaultColsGrid.upDownCol(row, true); }, ''],
+			['\u2193', function (aEvent) { miczColumnsWizardPref_DefaultColsGrid.upDownCol(row, false); }, '']].map(function (attributes) {
+				let element = doc.createElementNS(XUL, "toolbarbutton");
+				element.setAttribute("label", attributes[0]);
+				element.addEventListener("command", attributes[1], false);
+				if (attributes[2]) element.classList.add(attributes[2]);
+				return element;
+			});
 
-		  row.classList.add(colClass);
-		  [col_id, col_enable, col_sortby, col_title, col_flex, up, down].forEach( function(item) {
+		row.classList.add(colClass);
+		[col_id, col_enable, col_sortby, col_title, col_flex, up, down].forEach(function (item) {
 			row.insertBefore(item, null);
-		  } );
-		  container.insertBefore(row, ref);
-		  //dump(">>>>>>>>>>>>> miczColumnsWizard: [miczColumnsWizardPref_DefaultColsGrid createOneDefaultColRow] "+currindex+"\r\n");
-		  return row;
-		/*} catch(err) {
+		});
+		container.insertBefore(row, ref);
+		// dump(">>>>>>>>>>>>> miczColumnsWizard: [miczColumnsWizardPref_DefaultColsGrid createOneDefaultColRow] "+currindex+"\r\n");
+		return row;
+		/* } catch(err) {
 		  dump(">>>>>>>>>>>>> miczColumnsWizard: [miczColumnsWizardPref_DefaultColsGrid createOneDefaultColRow error] "+err+"\r\n");
 		}*/
 	},
 
-	saveDefaultColsGridRows: function(doc,container,save_pref) {
+	saveDefaultColsGridRows: function (doc, container, save_pref) {
 		let value = JSON.stringify(this.getDefaultCols(container));
-	  	if(save_pref){
-		  let preference = doc.getElementById("ColumnsWizard.DefaultColsList");
-		  preference.value = value;
-    	}
-    	return value;
+		if (save_pref) {
+			let preference = doc.getElementById("ColumnsWizard.DefaultColsList");
+			preference.value = value;
+		}
+		return value;
 	},
 
-	getDefaultCols:function(container){
-	    let cw_cols = {};
-	    let ordinal=1;
-		//try {
-		  if (!container){
-			//dump(">>>>>>>>>>>>> miczColumnsWizard: [getDefaultCols] no container\r\n");
-		  	return cw_cols;
-	  	  }
-		  for(let row of container.childNodes){
-			if(row.classList.contains(colClass)){
-			  let cw_col = this.getOneDefaultCol(row,ordinal);
-			  if(Object.keys(cw_col).length>0){
-				  cw_cols[cw_col.currindex]=cw_col;
-				  //dump(">>>>>>>>>>>>> miczColumnsWizard: [getDefaultCols] added cw_col {"+JSON.stringify(cw_col)+"}\r\n");
-			  }
-			  ordinal=ordinal+2;
+	getDefaultCols: function (container) {
+		let cw_cols = {};
+		let ordinal = 1;
+		// try {
+		if (!container) {
+			// dump(">>>>>>>>>>>>> miczColumnsWizard: [getDefaultCols] no container\r\n");
+			return cw_cols;
+		}
+		for (let row of container.childNodes) {
+			if (row.classList.contains(colClass)) {
+				let cw_col = this.getOneDefaultCol(row, ordinal);
+				if (Object.keys(cw_col).length > 0) {
+					cw_cols[cw_col.currindex] = cw_col;
+					// dump(">>>>>>>>>>>>> miczColumnsWizard: [getDefaultCols] added cw_col {"+JSON.stringify(cw_col)+"}\r\n");
+				}
+				ordinal = ordinal + 2;
 			}
-		  }
-		//} catch (err) { throw err; } // throw the error out so syncToPerf won't get an empty rules
+		}
+		// } catch (err) { throw err; } // throw the error out so syncToPerf won't get an empty rules
 		return cw_cols;
 	},
 
-	getOneDefaultCol: function(row,ordinal) {
-		let cwcol= {};
-		if(!ordinal)ordinal="1";
-	    //let ii=1;
-		for(let item of row.childNodes){
-		  let key = item.getAttribute('cwcol');
-		  if (key){
-			let value = item.value || item.checked;
-			if (item.getAttribute("type") == 'number') value = item.valueNumber;
-			if (item.getAttribute("type") == 'radio'){
-				 if(item.selected){
-					 //let prefsc = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
-					 //let prefs = prefsc.getBranch("mailnews.");
-					 //let sortcolindex=prefs.setIntPref("default_sort_type",miczColumnsWizardPref_DefaultColsGrid.getSortType(cwcol['currindex']));
-					 let sortcolindex=miczColumnsWizardPrefsUtils.setIntPref("mailnews.default_sort_type",miczColumnsWizardPref_DefaultColsGrid.getSortType(cwcol['currindex']));
-					 //dump(">>>>>>>>>>>>> miczColumnsWizard: [getOneDefaultCol col_id] "+cwcol['currindex']+"\r\n");
-				 }
-			 }else{
-				cwcol[key] = value;
-			 }
-			//dump(">>>>>>>>>>>>> miczColumnsWizard: "+ii+" [getOneDefaultCol key|value] "+key+"|"+cwcol[key]+"\r\n");
-			//dump(">>>>>>>>>>>>> miczColumnsWizard: [getOneDefaultCol] getting cwcol {"+JSON.stringify(cwcol)+"}\r\n");
-			//ii++;
-		  }
+	getOneDefaultCol: function (row, ordinal) {
+		let cwcol = {};
+		if (!ordinal) ordinal = "1";
+		// let ii=1;
+		for (let item of row.childNodes) {
+			let key = item.getAttribute('cwcol');
+			if (key) {
+				let value = item.value || item.checked;
+				if (item.getAttribute("type") === 'number') value = item.valueNumber;
+				if (item.getAttribute("type") === 'radio') {
+					if (item.selected) {
+						// let prefsc = Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefService);
+						// let prefs = prefsc.getBranch("mailnews.");
+						// let sortcolindex=prefs.setIntPref("default_sort_type",miczColumnsWizardPref_DefaultColsGrid.getSortType(cwcol['currindex']));
+						let sortcolindex = miczColumnsWizardPrefsUtils.setIntPref("mailnews.default_sort_type", miczColumnsWizardPref_DefaultColsGrid.getSortType(cwcol.currindex));
+						// dump(">>>>>>>>>>>>> miczColumnsWizard: [getOneDefaultCol col_id] "+cwcol['currindex']+"\r\n");
+					}
+				} else {
+					cwcol[key] = value;
+				}
+				// dump(">>>>>>>>>>>>> miczColumnsWizard: "+ii+" [getOneDefaultCol key|value] "+key+"|"+cwcol[key]+"\r\n");
+				// dump(">>>>>>>>>>>>> miczColumnsWizard: [getOneDefaultCol] getting cwcol {"+JSON.stringify(cwcol)+"}\r\n");
+				// ii++;
+			}
 		}
-		cwcol['ordinal']=ordinal;
-		 //dump(">>>>>>>>>>>>> miczColumnsWizard: [getOneDefaultCol] get cwcol {"+JSON.stringify(cwcol)+"}\r\n");
+		cwcol.ordinal = ordinal;
+		// dump(">>>>>>>>>>>>> miczColumnsWizard: [getOneDefaultCol] get cwcol {"+JSON.stringify(cwcol)+"}\r\n");
 		return cwcol;
-	  },
+	},
 
-  upDownCol: function(row, isUp) {
-	  let doc = row.ownerDocument;
-	  let container = doc.getElementById('ColumnsWizard.DefaultColsGrid');
-    //try {
-      let ref = isUp ? row.previousSibling : row;
-      let remove = isUp ? row : row.nextSibling;
-      if ( ref && remove && ref.classList.contains(colClass) && remove.classList.contains(colClass) ) {
-        let cwcol = this.getOneDefaultCol(remove);
-        remove.parentNode.removeChild(remove);
-        // remove.parentNode.insertBefore(remove, ref); // lost all unsaved values
-        let newBox = this.createOneDefaultColRow(doc,container,cwcol,ref);
-        //this.checkFocus( isUp ? newBox : row );
-        //this.syncToPerf(true);
-        this.saveDefaultColsGridRows(doc,container,true);
-      }
-    //} catch(err) {
-      //dump(">>>>>>>>>>>>> miczColumnsWizard: [miczColumnsWizardPref_DefaultColsGrid upDownCol error] "+err+"\r\n");
-    //}
-  },
+	upDownCol: function (row, isUp) {
+		let doc = row.ownerDocument;
+		let container = doc.getElementById('ColumnsWizard.DefaultColsGrid');
+		// try {
+		let ref = isUp ? row.previousSibling : row;
+		let remove = isUp ? row : row.nextSibling;
+		if (ref && remove && ref.classList.contains(colClass) && remove.classList.contains(colClass)) {
+			let cwcol = this.getOneDefaultCol(remove);
+			remove.parentNode.removeChild(remove);
+			// remove.parentNode.insertBefore(remove, ref); // lost all unsaved values
+			let newBox = this.createOneDefaultColRow(doc, container, cwcol, ref);
+			// this.checkFocus( isUp ? newBox : row );
+			// this.syncToPerf(true);
+			this.saveDefaultColsGridRows(doc, container, true);
+		}
+		// } catch(err) {
+		// dump(">>>>>>>>>>>>> miczColumnsWizard: [miczColumnsWizardPref_DefaultColsGrid upDownCol error] "+err+"\r\n");
+		// }
+	},
 
-	getColLocalizedString:function(col){
-		let strBundleCW = Components.classes["@mozilla.org/intl/stringbundle;1"].getService(Components.interfaces.nsIStringBundleService);
+	getColLocalizedString: function (col) {
+		let strBundleCW = Cc["@mozilla.org/intl/stringbundle;1"].getService(Ci.nsIStringBundleService);
 		let _bundleCW = strBundleCW.createBundle("chrome://columnswizard/locale/settings.properties");
-		let strOut=col;
+		let strOut = col;
 
 		switch (col) {
-    	 	case "threadCol":
-       		strOut = _bundleCW.GetStringFromName("ColumnsWizard.threadColumn.label");
-       		break;
-       		case "senderCol":
-       		strOut = _bundleCW.GetStringFromName("ColumnsWizard.fromColumn.label");
-       		break;
-       		case "recipientCol":
-       		strOut = _bundleCW.GetStringFromName("ColumnsWizard.recipientColumn.label");
-       		break;
-       		case "subjectCol":
-       		strOut = _bundleCW.GetStringFromName("ColumnsWizard.subjectColumn.label");
-       		break;
-       		case "dateCol":
-       		strOut = _bundleCW.GetStringFromName("ColumnsWizard.dateColumn.label");
-       		break;
-       		case "priorityCol":
-       		strOut = _bundleCW.GetStringFromName("ColumnsWizard.priorityColumn.label");
-       		break;
-       		case "tagsCol":
-       		strOut = _bundleCW.GetStringFromName("ColumnsWizard.tagsColumn.label");
-       		break;
-       		case "accountCol":
-       		strOut = _bundleCW.GetStringFromName("ColumnsWizard.accountColumn.label");
-       		break;
-       		case "statusCol":
-       		strOut = _bundleCW.GetStringFromName("ColumnsWizard.statusColumn.label");
-       		break;
-       		case "sizeCol":
-       		strOut = _bundleCW.GetStringFromName("ColumnsWizard.sizeColumn.label");
-       		break;
-       		case "junkStatusCol":
-       		strOut = _bundleCW.GetStringFromName("ColumnsWizard.junkStatusColumn.label");
-       		break;
-       		case "unreadCol":
-       		strOut = _bundleCW.GetStringFromName("ColumnsWizard.unreadColumn.label");
-       		break;
-       		case "totalCol":
-       		strOut = _bundleCW.GetStringFromName("ColumnsWizard.totalColumn.label");
-       		break;
-       		case "unreadButtonColHeader":
-       		strOut = _bundleCW.GetStringFromName("ColumnsWizard.readColumn.label");
-       		break;
-       		case "receivedCol":
-       		strOut = _bundleCW.GetStringFromName("ColumnsWizard.receivedColumn.label");
-       		break;
-       		case "flaggedCol":
-       		strOut = _bundleCW.GetStringFromName("ColumnsWizard.starredColumn.label");
-       		break;
-       		case "locationCol":
-       		strOut = _bundleCW.GetStringFromName("ColumnsWizard.locationColumn.label");
-       		break;
-       		case "idCol":
-       		strOut = _bundleCW.GetStringFromName("ColumnsWizard.idColumn.label");
-       		break;
-       		case "attachmentCol":
-       		strOut = _bundleCW.GetStringFromName("ColumnsWizard.attachmentColumn.label");
-       		break;
-       		case "correspondentCol":
-       		strOut = _bundleCW.GetStringFromName("ColumnsWizard.correspondentCol.label");
-       		break;
-       		default:
-				let col_idx=col.replace('Col_cw','');
-				let col_el=this.loadedCustCols[col_idx];
-				//dump(">>>>>>>>>>>>> miczColumnsWizard: [miczColumnsWizardPref_DefaultColsGrid] col_idx "+col_idx+"\r\n");
+			case "threadCol":
+				strOut = _bundleCW.GetStringFromName("ColumnsWizard.threadColumn.label");
+				break;
+			case "senderCol":
+				strOut = _bundleCW.GetStringFromName("ColumnsWizard.fromColumn.label");
+				break;
+			case "recipientCol":
+				strOut = _bundleCW.GetStringFromName("ColumnsWizard.recipientColumn.label");
+				break;
+			case "subjectCol":
+				strOut = _bundleCW.GetStringFromName("ColumnsWizard.subjectColumn.label");
+				break;
+			case "dateCol":
+				strOut = _bundleCW.GetStringFromName("ColumnsWizard.dateColumn.label");
+				break;
+			case "priorityCol":
+				strOut = _bundleCW.GetStringFromName("ColumnsWizard.priorityColumn.label");
+				break;
+			case "tagsCol":
+				strOut = _bundleCW.GetStringFromName("ColumnsWizard.tagsColumn.label");
+				break;
+			case "accountCol":
+				strOut = _bundleCW.GetStringFromName("ColumnsWizard.accountColumn.label");
+				break;
+			case "statusCol":
+				strOut = _bundleCW.GetStringFromName("ColumnsWizard.statusColumn.label");
+				break;
+			case "sizeCol":
+				strOut = _bundleCW.GetStringFromName("ColumnsWizard.sizeColumn.label");
+				break;
+			case "junkStatusCol":
+				strOut = _bundleCW.GetStringFromName("ColumnsWizard.junkStatusColumn.label");
+				break;
+			case "unreadCol":
+				strOut = _bundleCW.GetStringFromName("ColumnsWizard.unreadColumn.label");
+				break;
+			case "totalCol":
+				strOut = _bundleCW.GetStringFromName("ColumnsWizard.totalColumn.label");
+				break;
+			case "unreadButtonColHeader":
+				strOut = _bundleCW.GetStringFromName("ColumnsWizard.readColumn.label");
+				break;
+			case "receivedCol":
+				strOut = _bundleCW.GetStringFromName("ColumnsWizard.receivedColumn.label");
+				break;
+			case "flaggedCol":
+				strOut = _bundleCW.GetStringFromName("ColumnsWizard.starredColumn.label");
+				break;
+			case "locationCol":
+				strOut = _bundleCW.GetStringFromName("ColumnsWizard.locationColumn.label");
+				break;
+			case "idCol":
+				strOut = _bundleCW.GetStringFromName("ColumnsWizard.idColumn.label");
+				break;
+			case "attachmentCol":
+				strOut = _bundleCW.GetStringFromName("ColumnsWizard.attachmentColumn.label");
+				break;
+			case "correspondentCol":
+				strOut = _bundleCW.GetStringFromName("ColumnsWizard.correspondentCol.label");
+				break;
+			default:
+				let col_idx = col.replace('Col_cw', '');
+				let col_el = this.loadedCustCols[col_idx];
+				// dump(">>>>>>>>>>>>> miczColumnsWizard: [miczColumnsWizardPref_DefaultColsGrid] col_idx "+col_idx+"\r\n");
 				let _bundleCW_overlay = strBundleCW.createBundle("chrome://columnswizard/locale/overlay.properties");
-			    if(this.loadedCustCols[col_idx]){
-					if(col_el.isBundled){
-						strOut=_bundleCW_overlay.GetStringFromName("ColumnsWizard"+col_el.index+".label");
-					}else{
-						strOut=col_el.labelString;
+				if (this.loadedCustCols[col_idx]) {
+					if (col_el.isBundled) {
+						strOut = _bundleCW_overlay.GetStringFromName("ColumnsWizard" + col_el.index + ".label");
+					} else {
+						strOut = col_el.labelString;
 					}
 				}
-       		break;
-	   }
-	   return strOut;
+				break;
+		}
+		return strOut;
 	},
 
-	getSortOrder:function(sort_order){
-		let nsMsgViewSortOrder = Components.interfaces.nsMsgViewSortOrder;
+	getSortOrder: function (sort_order) {
+		let nsMsgViewSortOrder = Ci.nsMsgViewSortOrder;
 
 		switch (sort_order) {
-    	 	case "ASC":
-       		return nsMsgViewSortOrder.ascending;
-       		break;
-       		case "DESC":
-       		return nsMsgViewSortOrder.descending;
-       		break;
-	   }
-	   return nsMsgViewSortOrder.ascending;
+			case "ASC":
+				return nsMsgViewSortOrder.ascending;
+			case "DESC":
+				return nsMsgViewSortOrder.descending;
+		}
+		return nsMsgViewSortOrder.ascending;
 	},
 
-	getSortType:function(col){
-		let nsMsgViewSortType = Components.interfaces.nsMsgViewSortType;
+	getSortType: function (col) {
+		let nsMsgViewSortType = Ci.nsMsgViewSortType;
 
 		switch (col) {
-    	 	case "threadCol":
-       		return nsMsgViewSortType.byThread;
-       		break;
-       		case "senderCol":
-       		return nsMsgViewSortType.byAuthor;
-       		break;
-       		case "recipientCol":
-       		return nsMsgViewSortType.byRecipient;
-       		break;
-       		case "subjectCol":
-       		return nsMsgViewSortType.bySubject;
-       		break;
-       		case "dateCol":
-       		return nsMsgViewSortType.byDate;
-       		break;
-       		case "priorityCol":
-       		return nsMsgViewSortType.byPriority;
-       		break;
-       		case "tagsCol":
-       		return nsMsgViewSortType.byTags;
-       		break;
-       		case "accountCol":
-       		return nsMsgViewSortType.byAccount;
-       		break;
-       		case "statusCol":
-       		return nsMsgViewSortType.byStatus;
-       		break;
-       		case "sizeCol":
-       		return nsMsgViewSortType.bySize;
-       		break;
-       		case "junkStatusCol":
-       		return nsMsgViewSortType.byJunkStatus;
-       		break;
-       		/*case "unreadCol":
-       		return nsMsgViewSortType.;
-       		break;*/
-       		/*case "totalCol":
-       		return nsMsgViewSortType.;
-       		break;*/
-       		case "unreadButtonColHeader":
-       		return nsMsgViewSortType.byUnread;
-       		break;
-       		case "receivedCol":
-       		return nsMsgViewSortType.byReceived;
-       		break;
-       		case "flaggedCol":
-       		return nsMsgViewSortType.byFlagged;
-       		break;
-       		case "locationCol":
-       		return nsMsgViewSortType.byLocation;
-       		break;
-       		case "idCol":
-       		return nsMsgViewSortType.byId;
-       		break;
-       		case "attachmentCol":
-           	return nsMsgViewSortType.byAttachments;
-           	break;
-       		case "correspondentCol":
-           	return nsMsgViewSortType.byCorrespondent;
-           	break;
-       		default:
-       		//return nsMsgViewSortType.byCustom;
-       		//No sorting bycustom at the moment
-       		return -1;
-       		break;
-	   }
-	   return strOut;
+			case "threadCol":
+				return nsMsgViewSortType.byThread;
+			case "senderCol":
+				return nsMsgViewSortType.byAuthor;
+			case "recipientCol":
+				return nsMsgViewSortType.byRecipient;
+			case "subjectCol":
+				return nsMsgViewSortType.bySubject;
+			case "dateCol":
+				return nsMsgViewSortType.byDate;
+			case "priorityCol":
+				return nsMsgViewSortType.byPriority;
+			case "tagsCol":
+				return nsMsgViewSortType.byTags;
+			case "accountCol":
+				return nsMsgViewSortType.byAccount;
+			case "statusCol":
+				return nsMsgViewSortType.byStatus;
+			case "sizeCol":
+				return nsMsgViewSortType.bySize;
+			case "junkStatusCol":
+				return nsMsgViewSortType.byJunkStatus;
+			/* case "unreadCol":
+			return nsMsgViewSortType.;
+			break;*/
+			/* case "totalCol":
+			return nsMsgViewSortType.;
+			break;*/
+			case "unreadButtonColHeader":
+				return nsMsgViewSortType.byUnread;
+			case "receivedCol":
+				return nsMsgViewSortType.byReceived;
+			case "flaggedCol":
+				return nsMsgViewSortType.byFlagged;
+			case "locationCol":
+				return nsMsgViewSortType.byLocation;
+			case "idCol":
+				return nsMsgViewSortType.byId;
+			case "attachmentCol":
+				return nsMsgViewSortType.byAttachments;
+			case "correspondentCol":
+				return nsMsgViewSortType.byCorrespondent;
+			default:
+				// return nsMsgViewSortType.byCustom;
+				// No sorting bycustom at the moment
+				return -1;
+		}
 	},
 
 };

--- a/src/chrome/content/mzcw-defaultcolsgrid.jsm
+++ b/src/chrome/content/mzcw-defaultcolsgrid.jsm
@@ -73,7 +73,7 @@ var miczColumnsWizardPref_DefaultColsGrid = {
 		let _bundleCW = Services.strings.createBundle("chrome://columnswizard/locale/overlay.properties");
 
 		if (!container) return;
-		while (container.firstChild) container.removeChild(container.firstChild);
+		while (container.firstChild) container.firstChild.remove();
 		let row = doc.createElementNS(XUL, "row"); // header does not have class colClass
 		["show", "sort_by", "col_title", "col_flex", "up", "down"].forEach(function (label) {
 			let item = doc.createElementNS(XUL, "label");
@@ -255,7 +255,8 @@ var miczColumnsWizardPref_DefaultColsGrid = {
 		let remove = isUp ? row : row.nextSibling;
 		if (ref && remove && ref.classList.contains(colClass) && remove.classList.contains(colClass)) {
 			let cwcol = this.getOneDefaultCol(remove);
-			remove.parentNode.removeChild(remove);
+			// Check
+			remove.remove();
 			// remove.parentNode.insertBefore(remove, ref); // lost all unsaved values
 			let newBox = this.createOneDefaultColRow(doc, container, cwcol, ref);
 			// this.checkFocus( isUp ? newBox : row );

--- a/src/chrome/content/mzcw-defaultcolsgrid.jsm
+++ b/src/chrome/content/mzcw-defaultcolsgrid.jsm
@@ -1,4 +1,6 @@
 "use strict";
+
+const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 ChromeUtils.import("chrome://columnswizard/content/mzcw-prefsutils.jsm");
 
 var EXPORTED_SYMBOLS = ["miczColumnsWizardPref_DefaultColsGrid"];
@@ -68,9 +70,8 @@ var miczColumnsWizardPref_DefaultColsGrid = {
 
 	createDefaultColsGridHeader: function (doc, container) {
 		const XUL = "http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul";
-		let strBundleCW = Cc["@mozilla.org/intl/stringbundle;1"].getService(Ci.nsIStringBundleService);
-		let _bundleCW = strBundleCW.createBundle("chrome://columnswizard/locale/overlay.properties");
-		// try {
+		let _bundleCW = Services.strings.createBundle("chrome://columnswizard/locale/overlay.properties");
+
 		if (!container) return;
 		while (container.firstChild) container.removeChild(container.firstChild);
 		let row = doc.createElementNS(XUL, "row"); // header does not have class colClass
@@ -267,8 +268,7 @@ var miczColumnsWizardPref_DefaultColsGrid = {
 	},
 
 	getColLocalizedString: function (col) {
-		let strBundleCW = Cc["@mozilla.org/intl/stringbundle;1"].getService(Ci.nsIStringBundleService);
-		let _bundleCW = strBundleCW.createBundle("chrome://columnswizard/locale/settings.properties");
+		let _bundleCW = Services.strings.createBundle("chrome://columnswizard/locale/settings.properties");
 		let strOut = col;
 
 		switch (col) {
@@ -336,7 +336,7 @@ var miczColumnsWizardPref_DefaultColsGrid = {
 				let col_idx = col.replace('Col_cw', '');
 				let col_el = this.loadedCustCols[col_idx];
 				// dump(">>>>>>>>>>>>> miczColumnsWizard: [miczColumnsWizardPref_DefaultColsGrid] col_idx "+col_idx+"\r\n");
-				let _bundleCW_overlay = strBundleCW.createBundle("chrome://columnswizard/locale/overlay.properties");
+				let _bundleCW_overlay = Services.strings.createBundle("chrome://columnswizard/locale/overlay.properties");
 				if (this.loadedCustCols[col_idx]) {
 					if (col_el.isBundled) {
 						strOut = _bundleCW_overlay.GetStringFromName("ColumnsWizard" + col_el.index + ".label");

--- a/src/chrome/content/mzcw-folderlistener.js
+++ b/src/chrome/content/mzcw-folderlistener.js
@@ -1,8 +1,9 @@
 "use strict";
+
 ChromeUtils.import("chrome://columnswizard/content/mzcw-defaultcolsgrid.jsm");
 ChromeUtils.import("chrome://columnswizard/content/mzcw-prefsutils.jsm");
 
-miczColumnsWizard.FolderListener={
+miczColumnsWizard.FolderListener = {
 
 
     /**
@@ -13,141 +14,133 @@ miczColumnsWizard.FolderListener={
      *
      * Thanks to https://github.com/ju1ius for the initial code
      **/
-    OnItemAdded: function(parent_item, item)
-    {
-		//let prefsc = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
-		//let prefs = prefsc.getBranch("extensions.ColumnsWizard.DefaultColsList.");
-		//let cw_active=prefs.getBoolPref("active");
-		let cw_active=miczColumnsWizardPrefsUtils.defaultColsListActive;
+	OnItemAdded: function (parent_item, item) {
+		// let prefsc = Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefService);
+		// let prefs = prefsc.getBranch("extensions.ColumnsWizard.DefaultColsList.");
+		// let cw_active=prefs.getBoolPref("active");
+		let cw_active = miczColumnsWizardPrefsUtils.defaultColsListActive;
 
-		//dump(">>>>>>>>>>>>> miczColumnsWizard: [folder OnItemAdded triggered] "+item.name+"\r\n");
-        // Not a Folder...
-        if (!(item instanceof Components.interfaces.nsIMsgFolder)) {
-			//dump(">>>>>>>>>>>>> miczColumnsWizard: [folder OnItemAdded not a folder] "+item.name+"\r\n");
-            return;
-        }
-        // If no parent, this is an account
-        if (!parent_item) {
-			//dump(">>>>>>>>>>>>> miczColumnsWizard: [folder OnItemAdded no parent] "+item.name+"\r\n");
-            return;
-        }
-        if (miczColumnsWizard.FolderListener.isTrash(item) || miczColumnsWizard.FolderListener.isJunk(item)) {
-			//dump(">>>>>>>>>>>>> miczColumnsWizard: [folder OnItemAdded special folder] "+item.name+"\r\n");
-            return;
-        }
-		//dump(">>>>>>>>>>>>> miczColumnsWizard: [folder OnItemAdded do it on] "+item.name+"\r\n");
-
-		//miczColumnsWizard.FolderListener.cw_showColumns(item);
-		if(cw_active) miczColumnsWizard.FolderListener.cw_showColumns_Pref(item);
-    },
-
-    OnItemEvent: function(item, event)
-    {
-        if (!(item instanceof Components.interfaces.nsIMsgFolder)) {
-            return;
-        }
-        if (miczColumnsWizard.FolderListener.isTrash(item) || miczColumnsWizard.FolderListener.isJunk(item)) {
-            return;
-        }
-        if (event.toString() == "RenameCompleted") {
-            //Nothing to do here...
-            //miczColumnsWizard.FolderListener.cw_showColumns(item);
-        }
-    },
-
-    OnItemRemoved: function (parent_item, item)
-    {
-        if (!(item instanceof Components.interfaces.nsIMsgFolder)) {
-            return;
-        }
+		// dump(">>>>>>>>>>>>> miczColumnsWizard: [folder OnItemAdded triggered] "+item.name+"\r\n");
+		// Not a Folder...
+		if (!(item instanceof Ci.nsIMsgFolder)) {
+			// dump(">>>>>>>>>>>>> miczColumnsWizard: [folder OnItemAdded not a folder] "+item.name+"\r\n");
+			return;
+		}
+		// If no parent, this is an account
+		if (!parent_item) {
+			// dump(">>>>>>>>>>>>> miczColumnsWizard: [folder OnItemAdded no parent] "+item.name+"\r\n");
+			return;
+		}
 		if (miczColumnsWizard.FolderListener.isTrash(item) || miczColumnsWizard.FolderListener.isJunk(item)) {
-            return;
-        }
-		//Nothing to do here...
-    },
+			// dump(">>>>>>>>>>>>> miczColumnsWizard: [folder OnItemAdded special folder] "+item.name+"\r\n");
+			return;
+		}
+		// dump(">>>>>>>>>>>>> miczColumnsWizard: [folder OnItemAdded do it on] "+item.name+"\r\n");
 
-    isInbox: function(folder)
-    {
-        return folder.isSpecialFolder(Components.interfaces.nsMsgFolderFlags.Inbox, false);
-    },
-
-    isTrash: function(folder)
-    {
-        return folder.isSpecialFolder(Components.interfaces.nsMsgFolderFlags.Trash, true);
-    },
-
-    isVirtual: function(folder, check_parents)
-    {
-        check_parents = !!check_parents;
-        return folder.isSpecialFolder(Components.interfaces.nsMsgFolderFlags.Virtual, check_parents);
-    },
-
-    isJunk: function(folder)
-    {
-        return folder.isSpecialFolder(Components.interfaces.nsMsgFolderFlags.Junk, true);
-    },
-
-    isLeafFolder: function(folder)
-    {
-        var hasSubFolders = folder.hasSubFolders,
-            hasMessages = folder.getTotalMessages(false),
-            isSpecial = folder.isSpecialFolder(Components.interfaces.nsMsgFolderFlags.Virtual
-                                                | Components.interfaces.nsMsgFolderFlags.Trash
-                                                | Components.interfaces.nsMsgFolderFlags.Inbox
-                                                | Components.interfaces.nsMsgFolderFlags.Junk,
-                                                false);
-        return !hasSubFolders && !hasMessages;
-    },
-
-	cw_showColumns: function(item){
-		 let propName = gFolderDisplay.PERSISTED_COLUMN_PROPERTY_NAME;
-		 //dump(">>>>>>>>>>>>> miczColumnsWizard: [folder OnItemAdded propName] "+propName+"\r\n");
-         let dbFolderInfo = item.msgDatabase.dBFolderInfo;
-         let cwcolumnStatesString = dbFolderInfo.getCharProperty(propName);
-         //dump(">>>>>>>>>>>>> miczColumnsWizard: [folder OnItemAdded columnsStateString] "+cwcolumnStatesString+"...\r\n");
-         let cwcolumnStates=Array();
-         if(cwcolumnStatesString!=''){
-			 cwcolumnStates = JSON.parse(cwcolumnStatesString);
-			 //dump(">>>>>>>>>>>>> miczColumnsWizard: [folder OnItemAdded columnsStateString parsed]\r\n");
-		 }else{
-			 //dump(">>>>>>>>>>>>> miczColumnsWizard: [folder OnItemAdded columnsStateString empty Array]\r\n");
-			 cwcolumnStates=gFolderDisplay.getColumnStates();
-		 }
-		 //Choose which columns we need to always show...
-		 //For the moment we always show the active custom columns.
-		 let cwCustColPref=miczColumnsWizard.loadCustCols();
-		 let lastordinal=(cwcolumnStates[index+'ccCol_cw'].ordinal=='0')||(cwcolumnStates['ccCol_cw'].ordinal=='null')?(Object.keys(cwcolumnStates).length)+1:cwcolumnStates['ccCol_cw'].ordinal;
-		 lastordinal=(lastordinal % 2)==0?lastordinal+2:lastordinal+1;
-
-		 for (let index in cwCustColPref) {
-			 if(cwCustColPref[index].Pref){
-				 if(!(index+'Col_cw' in cwcolumnStates)){
-					 //dump(">>>>>>>>>>>>> miczColumnsWizard: [folder OnItemAdded cwcolumnStates['"+index+"Col_cw'] is false]\r\n");
-					cwcolumnStates[index+'Col_cw']={visible:true,ordinal:lastordinal};
-				 }else{
-					 //dump(">>>>>>>>>>>>> miczColumnsWizard: [folder OnItemAdded cwcolumnStates['"+index+"Col_cw'].ordinal] "+cwcolumnStates[index+'Col_cw'].ordinal+"\r\n");
-					 //dump(">>>>>>>>>>>>> miczColumnsWizard: [folder OnItemAdded lastordinal] "+lastordinal+" | "+typeof lastordinal+"\r\n");
-					 cwcolumnStates[index+'Col_cw']={visible:true,ordinal:lastordinal};
-			 	}
-			 	lastordinal=lastordinal+2;
-			 }
-		 }
-		 //dump(">>>>>>>>>>>>> miczColumnsWizard: [folder OnItemAdded columnsStateString NEW] "+JSON.stringify(cwcolumnStates)+"\r\n");
-		 dbFolderInfo.setCharProperty(propName,JSON.stringify(cwcolumnStates));
-		 item.msgDatabase.Commit(Components.interfaces.nsMsgDBCommitType.kLargeCommit);
+		// miczColumnsWizard.FolderListener.cw_showColumns(item);
+		if (cw_active) miczColumnsWizard.FolderListener.cw_showColumns_Pref(item);
 	},
 
-	cw_showColumns_Pref: function(item){
-		 let propName = gFolderDisplay.PERSISTED_COLUMN_PROPERTY_NAME;
-		 let dbFolderInfo = item.msgDatabase.dBFolderInfo;
-         let cwcolumnStates=miczColumnsWizardPref_DefaultColsGrid.loadDefaultColRows_Pref();
-		 //dump(">>>>>>>>>>>>> miczColumnsWizard: [cw_showColumns_Pref] "+JSON.stringify(cwcolumnStates)+"\r\n");
-		 dbFolderInfo.setCharProperty(propName,JSON.stringify(cwcolumnStates));
-		 /*let wMediator = Components.classes["@mozilla.org/appshell/window-mediator;1"].getService(Components.interfaces.nsIWindowMediator);
-		 let mainWindow = wMediator.getMostRecentWindow("mail:3pane");
-		 let sortedColumn=mainWindow.document.getElementById('ccCol_cw');
-		 sortedColumn.setAttribute("width","30px");*/
-		 item.msgDatabase.Commit(Components.interfaces.nsMsgDBCommitType.kLargeCommit);
+	OnItemEvent: function (item, event) {
+		if (!(item instanceof Ci.nsIMsgFolder)) {
+			return;
+		}
+		if (miczColumnsWizard.FolderListener.isTrash(item) || miczColumnsWizard.FolderListener.isJunk(item)) {
+			return;
+		}
+		if (event.toString() === "RenameCompleted") {
+			// Nothing to do here...
+			// miczColumnsWizard.FolderListener.cw_showColumns(item);
+		}
+	},
+
+	OnItemRemoved: function (parent_item, item) {
+		if (!(item instanceof Ci.nsIMsgFolder)) {
+			return;
+		}
+		if (miczColumnsWizard.FolderListener.isTrash(item) || miczColumnsWizard.FolderListener.isJunk(item)) {
+			return;
+		}
+		// Nothing to do here...
+	},
+
+	isInbox: function (folder) {
+		return folder.isSpecialFolder(Ci.nsMsgFolderFlags.Inbox, false);
+	},
+
+	isTrash: function (folder) {
+		return folder.isSpecialFolder(Ci.nsMsgFolderFlags.Trash, true);
+	},
+
+	isVirtual: function (folder, check_parents) {
+		check_parents = !!check_parents;
+		return folder.isSpecialFolder(Ci.nsMsgFolderFlags.Virtual, check_parents);
+	},
+
+	isJunk: function (folder) {
+		return folder.isSpecialFolder(Ci.nsMsgFolderFlags.Junk, true);
+	},
+
+	isLeafFolder: function (folder) {
+		var hasSubFolders = folder.hasSubFolders,
+			hasMessages = folder.getTotalMessages(false),
+			isSpecial = folder.isSpecialFolder(Ci.nsMsgFolderFlags.Virtual
+				| Ci.nsMsgFolderFlags.Trash
+				| Ci.nsMsgFolderFlags.Inbox
+				| Ci.nsMsgFolderFlags.Junk,
+				false);
+		return !hasSubFolders && !hasMessages;
+	},
+
+	cw_showColumns: function (item) {
+		let propName = gFolderDisplay.PERSISTED_COLUMN_PROPERTY_NAME;
+		// dump(">>>>>>>>>>>>> miczColumnsWizard: [folder OnItemAdded propName] "+propName+"\r\n");
+		let dbFolderInfo = item.msgDatabase.dBFolderInfo;
+		let cwcolumnStatesString = dbFolderInfo.getCharProperty(propName);
+		// dump(">>>>>>>>>>>>> miczColumnsWizard: [folder OnItemAdded columnsStateString] "+cwcolumnStatesString+"...\r\n");
+		let cwcolumnStates = [];
+		if (cwcolumnStatesString !== '') {
+			cwcolumnStates = JSON.parse(cwcolumnStatesString);
+			// dump(">>>>>>>>>>>>> miczColumnsWizard: [folder OnItemAdded columnsStateString parsed]\r\n");
+		} else {
+			// dump(">>>>>>>>>>>>> miczColumnsWizard: [folder OnItemAdded columnsStateString empty Array]\r\n");
+			cwcolumnStates = gFolderDisplay.getColumnStates();
+		}
+		// Choose which columns we need to always show...
+		// For the moment we always show the active custom columns.
+		let cwCustColPref = miczColumnsWizard.loadCustCols();
+		let lastordinal = (cwcolumnStates[index + 'ccCol_cw'].ordinal === '0') || (cwcolumnStates['ccCol_cw'].ordinal === 'null') ? (Object.keys(cwcolumnStates).length) + 1 : cwcolumnStates['ccCol_cw'].ordinal;
+		lastordinal = (lastordinal % 2) === 0 ? lastordinal + 2 : lastordinal + 1;
+
+		for (let index in cwCustColPref) {
+			if (cwCustColPref[index].Pref) {
+				if (!(index + 'Col_cw' in cwcolumnStates)) {
+					// dump(">>>>>>>>>>>>> miczColumnsWizard: [folder OnItemAdded cwcolumnStates['"+index+"Col_cw'] is false]\r\n");
+					cwcolumnStates[index + 'Col_cw'] = { visible: true, ordinal: lastordinal };
+				} else {
+					// dump(">>>>>>>>>>>>> miczColumnsWizard: [folder OnItemAdded cwcolumnStates['"+index+"Col_cw'].ordinal] "+cwcolumnStates[index+'Col_cw'].ordinal+"\r\n");
+					// dump(">>>>>>>>>>>>> miczColumnsWizard: [folder OnItemAdded lastordinal] "+lastordinal+" | "+typeof lastordinal+"\r\n");
+					cwcolumnStates[index + 'Col_cw'] = { visible: true, ordinal: lastordinal };
+				}
+				lastordinal = lastordinal + 2;
+			}
+		}
+		// dump(">>>>>>>>>>>>> miczColumnsWizard: [folder OnItemAdded columnsStateString NEW] "+JSON.stringify(cwcolumnStates)+"\r\n");
+		dbFolderInfo.setCharProperty(propName, JSON.stringify(cwcolumnStates));
+		item.msgDatabase.Commit(Ci.nsMsgDBCommitType.kLargeCommit);
+	},
+
+	cw_showColumns_Pref: function (item) {
+		let propName = gFolderDisplay.PERSISTED_COLUMN_PROPERTY_NAME;
+		let dbFolderInfo = item.msgDatabase.dBFolderInfo;
+		let cwcolumnStates = miczColumnsWizardPref_DefaultColsGrid.loadDefaultColRows_Pref();
+		// dump(">>>>>>>>>>>>> miczColumnsWizard: [cw_showColumns_Pref] "+JSON.stringify(cwcolumnStates)+"\r\n");
+		dbFolderInfo.setCharProperty(propName, JSON.stringify(cwcolumnStates));
+		/* let wMediator = Cc["@mozilla.org/appshell/window-mediator;1"].getService(Ci.nsIWindowMediator);
+		let mainWindow = wMediator.getMostRecentWindow("mail:3pane");
+		let sortedColumn=mainWindow.document.getElementById('ccCol_cw');
+		sortedColumn.setAttribute("width","30px");*/
+		item.msgDatabase.Commit(Ci.nsMsgDBCommitType.kLargeCommit);
 	},
 
 };

--- a/src/chrome/content/mzcw-folderlistener.js
+++ b/src/chrome/content/mzcw-folderlistener.js
@@ -109,6 +109,7 @@ miczColumnsWizard.FolderListener = {
 		// Choose which columns we need to always show...
 		// For the moment we always show the active custom columns.
 		let cwCustColPref = miczColumnsWizard.loadCustCols();
+		// Check
 		let lastordinal = (cwcolumnStates[index + 'ccCol_cw'].ordinal === '0') || (cwcolumnStates['ccCol_cw'].ordinal === 'null') ? (Object.keys(cwcolumnStates).length) + 1 : cwcolumnStates['ccCol_cw'].ordinal;
 		lastordinal = (lastordinal % 2) === 0 ? lastordinal + 2 : lastordinal + 1;
 

--- a/src/chrome/content/mzcw-mailheader-editor.js
+++ b/src/chrome/content/mzcw-mailheader-editor.js
@@ -1,46 +1,46 @@
 "use strict";
 ChromeUtils.import("chrome://columnswizard/content/mzcw-customcolsmodutils.jsm");
 
-var miczColumnsWizard={};
+var miczColumnsWizard = {};
 var miczColumnsWizard_MailHeaderEditor = {
-	
-	_only_numbers:false,
-	_sanitize_value_regex:"\\d+",
 
-	onLoad: function(){
-		//Fixing window height
+	_only_numbers: false,
+	_sanitize_value_regex: "\\d+",
+
+	onLoad: function () {
+		// Fixing window height
 		this.fixWinHeight();
 
-		if ("arguments" in window && window.arguments[0]){
+		if ("arguments" in window && window.arguments[0]) {
 			let args = window.arguments[0];
-			
-			this._only_numbers=args.edit_type==miczColumnsWizard_CustomColsModUtils.editTypeNumbers;
-			//dump(">>>>>>>>>>>>> miczColumnsWizard_MailHeaderEditor: [onLoad]: this._only_numbers: "+JSON.stringify(this._only_numbers)+"\r\n");
-			//dump(">>>>>>>>>>>>> miczColumnsWizard_MailHeaderEditor: [onLoad]: args.edit_type: "+JSON.stringify(args.edit_type)+"\r\n");
-			
-			document.getElementById("cw_only_numbers_label").setAttribute("hidden",!this._only_numbers);
 
-			if ("action" in args){
-				switch (args.action){
+			this._only_numbers = args.edit_type === miczColumnsWizard_CustomColsModUtils.editTypeNumbers;
+			// dump(">>>>>>>>>>>>> miczColumnsWizard_MailHeaderEditor: [onLoad]: this._only_numbers: "+JSON.stringify(this._only_numbers)+"\r\n");
+			// dump(">>>>>>>>>>>>> miczColumnsWizard_MailHeaderEditor: [onLoad]: args.edit_type: "+JSON.stringify(args.edit_type)+"\r\n");
+
+			document.getElementById("cw_only_numbers_label").setAttribute("hidden", !this._only_numbers);
+
+			if ("action" in args) {
+				switch (args.action) {
 					case "change":
-						document.getElementById("ColumnsWizard.mail_header.value").setAttribute("value",args.value);
-					break;
+						document.getElementById("ColumnsWizard.mail_header.value").setAttribute("value", args.value);
+						break;
 				}
 			}
 		}
 	},
 
-	onAccept:function(){
+	onAccept: function () {
 
-		if ("arguments" in window && window.arguments[0]){
+		if ("arguments" in window && window.arguments[0]) {
 			let args = window.arguments[0];
 
-			if ("action" in args){
-				switch (args.action){
-					case "change":  //Save new custom column
-						window.arguments[0].save=true;
-						window.arguments[0].value=document.getElementById("ColumnsWizard.mail_header.value").value;
-					break;
+			if ("action" in args) {
+				switch (args.action) {
+					case "change": // Save new custom column
+						window.arguments[0].save = true;
+						window.arguments[0].value = document.getElementById("ColumnsWizard.mail_header.value").value;
+						break;
 				}
 			}
 		}
@@ -48,17 +48,17 @@ var miczColumnsWizard_MailHeaderEditor = {
 		return true;
 	},
 
-	onBlur_sanitize_value:function(){
-		if(this._only_numbers){
-			let re=new RegExp(this._sanitize_value_regex,'ig');
-			let el=document.getElementById('ColumnsWizard.mail_header.value');
-			if(el.value.match(re)!=null){
-				el.value=el.value.match(re).join('');
+	onBlur_sanitize_value: function () {
+		if (this._only_numbers) {
+			let re = new RegExp(this._sanitize_value_regex, 'ig');
+			let el = document.getElementById('ColumnsWizard.mail_header.value');
+			if (el.value.match(re) !== null) {
+				el.value = el.value.match(re).join('');
 			}
 		}
 	},
 
-	fixWinHeight:function(){
+	fixWinHeight: function () {
 		sizeToContent();
 		var vbox = document.getElementById('cw_vbox_mhe');
 		vbox.height = vbox.boxObject.height;

--- a/src/chrome/content/mzcw-mailheader-editor.js
+++ b/src/chrome/content/mzcw-mailheader-editor.js
@@ -59,6 +59,7 @@ var miczColumnsWizard_MailHeaderEditor = {
 	},
 
 	fixWinHeight: function () {
+		// Check
 		sizeToContent();
 		var vbox = document.getElementById('cw_vbox_mhe');
 		vbox.height = vbox.boxObject.height;

--- a/src/chrome/content/mzcw-msgutils.jsm
+++ b/src/chrome/content/mzcw-msgutils.jsm
@@ -5,190 +5,190 @@
  * made by Paolo "Kaosmos".
  * */
 
+var EXPORTED_SYMBOLS = ["miczColumnsWizard_MsgUtils"];
+
+
 ChromeUtils.import("chrome://columnswizard/content/mzcw-prefsutils.jsm");
 ChromeUtils.import("resource://columnswizard/miczLogger.jsm");
 ChromeUtils.import("resource:///modules/mailServices.js");
 ChromeUtils.import("resource:///modules/iteratorUtils.jsm"); // for toXPCOMArray
 
 
-var EXPORTED_SYMBOLS = ["miczColumnsWizard_MsgUtils"];
-
 var miczColumnsWizard_MsgUtils = {
 
-	win:null,
-	list:null,
-	messenger:null,
-	mms:null,
-	folder:null,
-	hdr:null,
-	current_header:'',
-	new_header_value:'',
-	noTrash:false,
-	gDBView:null,
-	msgWindow:null,
-	mailServices:null,
-	tags:null,
+	win: null,
+	list: null,
+	messenger: null,
+	mms: null,
+	folder: null,
+	hdr: null,
+	current_header: '',
+	new_header_value: '',
+	noTrash: false,
+	gDBView: null,
+	msgWindow: null,
+	mailServices: null,
+	tags: null,
 
-	init:function(messenger,msgURI,gDBView,msgWindow,win){
-		miczColumnsWizard_MsgUtils.messenger=messenger;
-		miczColumnsWizard_MsgUtils.mms = miczColumnsWizard_MsgUtils.messenger.messageServiceFromURI(msgURI).QueryInterface(Components.interfaces.nsIMsgMessageService);
-		miczColumnsWizard_MsgUtils.hdr=miczColumnsWizard_MsgUtils.mms.messageURIToMsgHdr(msgURI);
-		miczColumnsWizard_MsgUtils.msgURI=msgURI;
-		miczColumnsWizard_MsgUtils.folder=miczColumnsWizard_MsgUtils.hdr.folder;
-		miczColumnsWizard_MsgUtils.gDBView=gDBView;
-		miczColumnsWizard_MsgUtils.msgWindow=msgWindow;
-		miczColumnsWizard_MsgUtils.win=win;
-		miczColumnsWizard_MsgUtils.mailServices=MailServices;
-		miczColumnsWizard_MsgUtils.tags=miczColumnsWizard_MsgUtils.msgHdrGetTags(miczColumnsWizard_MsgUtils.hdr)
-		//miczLogger.log('miczColumnsWizard_MsgUtils.init miczColumnsWizard_MsgUtils.msgHdrGetTags: '+miczColumnsWizard_MsgUtils.tags);
+	init: function (messenger, msgURI, gDBView, msgWindow, win) {
+		miczColumnsWizard_MsgUtils.messenger = messenger;
+		miczColumnsWizard_MsgUtils.mms = miczColumnsWizard_MsgUtils.messenger.messageServiceFromURI(msgURI).QueryInterface(Ci.nsIMsgMessageService);
+		miczColumnsWizard_MsgUtils.hdr = miczColumnsWizard_MsgUtils.mms.messageURIToMsgHdr(msgURI);
+		miczColumnsWizard_MsgUtils.msgURI = msgURI;
+		miczColumnsWizard_MsgUtils.folder = miczColumnsWizard_MsgUtils.hdr.folder;
+		miczColumnsWizard_MsgUtils.gDBView = gDBView;
+		miczColumnsWizard_MsgUtils.msgWindow = msgWindow;
+		miczColumnsWizard_MsgUtils.win = win;
+		miczColumnsWizard_MsgUtils.mailServices = MailServices;
+		miczColumnsWizard_MsgUtils.tags = miczColumnsWizard_MsgUtils.msgHdrGetTags(miczColumnsWizard_MsgUtils.hdr);
+		// miczLogger.log('miczColumnsWizard_MsgUtils.init miczColumnsWizard_MsgUtils.msgHdrGetTags: '+miczColumnsWizard_MsgUtils.tags);
 	},
 
-	setCurrentHeader:function(header){
-		miczColumnsWizard_MsgUtils.current_header=header;
+	setCurrentHeader: function (header) {
+		miczColumnsWizard_MsgUtils.current_header = header;
 	},
 
-	getMsgHeaderValue:function(header){
-		//dump(">>>>>>>>>>>>> miczColumnsWizard_MsgUtils [getMsgHeader]: hrd: "+JSON.stringify(miczColumnsWizard_MsgUtils.hdr.getStringProperty(header))+" - header: "+header+"\r\n");
+	getMsgHeaderValue: function (header) {
+		// dump(">>>>>>>>>>>>> miczColumnsWizard_MsgUtils [getMsgHeader]: hrd: "+JSON.stringify(miczColumnsWizard_MsgUtils.hdr.getStringProperty(header))+" - header: "+header+"\r\n");
 		return miczColumnsWizard_MsgUtils.hdr.getStringProperty(header);
 	},
 
-	saveMsg:function(value,msgURI,listener){
-		miczColumnsWizard_MsgUtils.new_header_value=value;
+	saveMsg: function (value, msgURI, listener) {
+		miczColumnsWizard_MsgUtils.new_header_value = value;
 		miczColumnsWizard_MsgUtils.mms.streamMessage(msgURI, listener, null, null, false, null);
 	},
 
 	// parses headers to find the original Date header, not present in nsImsgDbHdr
-	getOrigDate:function(){
+	getOrigDate: function () {
 		let dateOrig = "";
 		let splitted = null;
 		try {
 			let str_message = miczColumnsWizard_MsgUtils.listener.text;
 			// This is the end of the headers
 			let end = str_message.search(/\r?\n\r?\n/);
-			if (str_message.indexOf("\nDate") > -1 && str_message.indexOf("\nDate")  < end)
-				splitted =str_message.split("\nDate:");
-			else if (str_message.indexOf("\ndate") > -1 && str_message.indexOf("\ndate")  < end)
-				splitted =str_message.split("\ndate:");
+			if (str_message.indexOf("\nDate") > -1 && str_message.indexOf("\nDate") < end)
+				splitted = str_message.split("\nDate:");
+			else if (str_message.indexOf("\ndate") > -1 && str_message.indexOf("\ndate") < end)
+				splitted = str_message.split("\ndate:");
 			if (splitted) {
 				dateOrig = splitted[1].split("\n")[0];
-				dateOrig = dateOrig.replace(/ +$/,"");
-				dateOrig = dateOrig.replace(/^ +/,"");
+				dateOrig = dateOrig.replace(/ +$/, "");
+				dateOrig = dateOrig.replace(/^ +/, "");
 			}
-		}
-		catch(e) {}
+		} catch (e) { }
 		return dateOrig;
 	},
 
-	cleanCRLF:function(data){
-	/*	This function forces all newline as CRLF; this is useful for some reasons
-		1) this will make the message RFC2822 compliant
-		2) this will fix some problems with IMAP servers that don't accept mixed newlines
-		3) this will make easier to use regexps
-		*/
+	cleanCRLF: function (data) {
+		/*	This function forces all newline as CRLF; this is useful for some reasons
+			1) this will make the message RFC2822 compliant
+			2) this will fix some problems with IMAP servers that don't accept mixed newlines
+			3) this will make easier to use regexps
+			*/
 		let newData = data.replace(/\r/g, "");
 		newData = newData.replace(/\n/g, "\r\n");
 		return newData;
 	},
 
-	postActions:function(key){
-		//miczLogger.log('miczColumnsWizard_MsgUtils.postActions START');
+	postActions: function (key) {
+		// miczLogger.log('miczColumnsWizard_MsgUtils.postActions START');
 		miczColumnsWizard_MsgUtils.gDBView.selectMsgByKey(key); // select message with modified headers/source
 		let hdr = miczColumnsWizard_MsgUtils.folder.GetMessageHeader(key);
-		//miczLogger.log('miczColumnsWizard_MsgUtils.postActions HDR DONE');
-		if(hdr.flags & 2){
-			miczColumnsWizard_MsgUtils.folder.addMessageDispositionState(hdr,0); //set replied if necessary
-			//miczLogger.log('miczColumnsWizard_MsgUtils.postActions REPLIED SET');
+		// miczLogger.log('miczColumnsWizard_MsgUtils.postActions HDR DONE');
+		if (hdr.flags & 2) {
+			miczColumnsWizard_MsgUtils.folder.addMessageDispositionState(hdr, 0); // set replied if necessary
+			// miczLogger.log('miczColumnsWizard_MsgUtils.postActions REPLIED SET');
 		}
-	    if(hdr.flags & 4096){
-			miczColumnsWizard_MsgUtils.folder.addMessageDispositionState(hdr,1); //set fowarded if necessary
-			//miczLogger.log('miczColumnsWizard_MsgUtils.postActions FORWARDED SET');
+		if (hdr.flags & 4096) {
+			miczColumnsWizard_MsgUtils.folder.addMessageDispositionState(hdr, 1); // set fowarded if necessary
+			// miczLogger.log('miczColumnsWizard_MsgUtils.postActions FORWARDED SET');
 		}
-	    //set labels if needed
-	   //miczLogger.log('miczColumnsWizard_MsgUtils.postActions SETTING LABELS');
-	    //miczLogger.log('miczColumnsWizard_MsgUtils.postActions miczColumnsWizard_MsgUtils.tags: '+miczColumnsWizard_MsgUtils.tags.join(" "));
-	    miczColumnsWizard_MsgUtils.folder.addKeywordsToMessages(toXPCOMArray([hdr], Components.interfaces.nsIMutableArray),miczColumnsWizard_MsgUtils.tags.join(" "));
-	    //miczLogger.log('miczColumnsWizard_MsgUtils.postActions LABELS SET');
+		// set labels if needed
+		// miczLogger.log('miczColumnsWizard_MsgUtils.postActions SETTING LABELS');
+		// miczLogger.log('miczColumnsWizard_MsgUtils.postActions miczColumnsWizard_MsgUtils.tags: '+miczColumnsWizard_MsgUtils.tags.join(" "));
+		miczColumnsWizard_MsgUtils.folder.addKeywordsToMessages(toXPCOMArray([hdr], Ci.nsIMutableArray), miczColumnsWizard_MsgUtils.tags.join(" "));
+		// miczLogger.log('miczColumnsWizard_MsgUtils.postActions LABELS SET');
 	},
-	
+
 	/**
 	 * Given a msgHdr, return a list of tag objects. This function
 	 * just does the messy work of understanding how tags are
 	 * stored in nsIMsgDBHdrs.
 	 */
-	msgHdrGetTags:function(aMsgHdr){
-	  let keywords = aMsgHdr.getStringProperty("keywords");
-	  let keywordList = keywords.split(' ');
-	  //miczLogger.log('miczColumnsWizard_MsgUtils.msgHdrGetTags keywords: '+keywords);
-	  //miczLogger.log('miczColumnsWizard_MsgUtils.msgHdrGetTags keywordList: '+keywordList);
-	  return keywordList;
+	msgHdrGetTags: function (aMsgHdr) {
+		let keywords = aMsgHdr.getStringProperty("keywords");
+		let keywordList = keywords.split(' ');
+		// miczLogger.log('miczColumnsWizard_MsgUtils.msgHdrGetTags keywords: '+keywords);
+		// miczLogger.log('miczColumnsWizard_MsgUtils.msgHdrGetTags keywordList: '+keywordList);
+		return keywordList;
 	},
 };
 
 miczColumnsWizard_MsgUtils.listener = {
 
-	text:"",
+	text: "",
 
-	QueryInterface:function(iid){
-		if (iid.equals(Components.interfaces.nsIStreamListener) || iid.equals(Components.interfaces.nsISupports)){
+	QueryInterface: function (iid) {
+		if (iid.equals(Ci.nsIStreamListener) || iid.equals(Ci.nsISupports)) {
 			return this;
 		}
-		throw Components.results.NS_NOINTERFACE;
+		throw Cr.NS_NOINTERFACE;
 		return 0;
 	},
 
-	onStartRequest:function(aRequest, aContext){
+	onStartRequest: function (aRequest, aContext) {
 		miczColumnsWizard_MsgUtils.listener.text = "";
 	},
 
-	onStopRequest:function(aRequest, aContext, aStatusCode){
-		let isImap = (miczColumnsWizard_MsgUtils.folder.server.type == "imap") ? true : false;
+	onStopRequest: function (aRequest, aContext, aStatusCode) {
+		let isImap = (miczColumnsWizard_MsgUtils.folder.server.type === "imap") ? true : false;
 		let date = miczColumnsWizard_MsgUtils.getOrigDate();
 
 		let data = miczColumnsWizard_MsgUtils.cleanCRLF(miczColumnsWizard_MsgUtils.listener.text);
 		let endHeaders = data.search(/\r\n\r\n/);
-		let headers = data.substring(0,endHeaders);
+		let headers = data.substring(0, endHeaders);
 
 		// unfold headers, if necessary
-		while(headers.match(/\r\nSubject: .*\r\n\s+/))
+		while (headers.match(/\r\nSubject: .*\r\n\s+/))
 			headers = headers.replace(/(\r\nSubject: .*)(\r\n\s+)/, "$1 ");
-		while(headers.match(/\r\nFrom: .*\r\n\s+/))
+		while (headers.match(/\r\nFrom: .*\r\n\s+/))
 			headers = headers.replace(/(\r\nFrom: .*)(\r\n\s+)/, "$1 ");
-		while(headers.match(/\r\nTo: .*\r\n\s+/))
+		while (headers.match(/\r\nTo: .*\r\n\s+/))
 			headers = headers.replace(/(\r\nTo: .*)(\r\n\s+)/, "$1 ");
 
 		// This will be removed after the if-else_if-else series, it will make easier to test headers
-		headers = "\n"+headers;
+		headers = "\n" + headers;
 
-		let currStrHeader="\n"+miczColumnsWizard_MsgUtils.current_header+":";
-		let mimeEncoder = Components.classes["@mozilla.org/messenger/mimeconverter;1"].getService(Components.interfaces.nsIMimeConverter);
+		let currStrHeader = "\n" + miczColumnsWizard_MsgUtils.current_header + ":";
+		let mimeEncoder = Cc["@mozilla.org/messenger/mimeconverter;1"].getService(Ci.nsIMimeConverter);
 		let newHeaderEnc = mimeEncoder.encodeMimePartIIStr_UTF8(miczColumnsWizard_MsgUtils.new_header_value, false, "UTF-8", 0, 72);
 
-		let re=new RegExp(currStrHeader+" *.*\r\n",'ig');
-		if (headers.indexOf(currStrHeader) > -1){
-			headers=headers+"\r\n";
-			headers = headers.replace(re, currStrHeader+" "+ newHeaderEnc+"\r\n");
-			//dump(">>>>>>>>>>>>> miczColumnsWizard_MsgUtils [listener]: REPLACING HEADER\r\n");
-			//dump(">>>>>>>>>>>>> miczColumnsWizard_MsgUtils [listener]: headers: "+headers+"\r\n");
-			headers = headers.substring(0,headers.length-2);
-		}else{ // header is missing
-			headers = headers+"\r"+currStrHeader+" "+newHeaderEnc+"\r\n";
-			//dump(">>>>>>>>>>>>> miczColumnsWizard_MsgUtils [listener]: ADDING HEADER\r\n");
+		let re = new RegExp(currStrHeader + " *.*\r\n", 'ig');
+		if (headers.indexOf(currStrHeader) > -1) {
+			headers = headers + "\r\n";
+			headers = headers.replace(re, currStrHeader + " " + newHeaderEnc + "\r\n");
+			// dump(">>>>>>>>>>>>> miczColumnsWizard_MsgUtils [listener]: REPLACING HEADER\r\n");
+			// dump(">>>>>>>>>>>>> miczColumnsWizard_MsgUtils [listener]: headers: "+headers+"\r\n");
+			headers = headers.substring(0, headers.length - 2);
+		} else { // header is missing
+			headers = headers + "\r" + currStrHeader + " " + newHeaderEnc + "\r\n";
+			// dump(">>>>>>>>>>>>> miczColumnsWizard_MsgUtils [listener]: ADDING HEADER\r\n");
 		}
 
-		//dump(">>>>>>>>>>>>> miczColumnsWizard_MsgUtils [listener]: newHeaderEnc: "+newHeaderEnc+"\r\n");
-		//dump(">>>>>>>>>>>>> miczColumnsWizard_MsgUtils [listener]: headers: "+headers+"\r\n");
+		// dump(">>>>>>>>>>>>> miczColumnsWizard_MsgUtils [listener]: newHeaderEnc: "+newHeaderEnc+"\r\n");
+		// dump(">>>>>>>>>>>>> miczColumnsWizard_MsgUtils [listener]: headers: "+headers+"\r\n");
 
 		headers = headers.substring(1);
 		data = headers + data.substring(endHeaders);
-		//let action = "headerChanged";
+		// let action = "headerChanged";
 
 		// strips off some useless headers
-		/*data = data.replace(/^From - .+\r\n/, "");
+		/* data = data.replace(/^From - .+\r\n/, "");
 		data = data.replace(/X-Mozilla-Status.+\r\n/, "");
 		data = data.replace(/X-Mozilla-Status2.+\r\n/, "");
 		data = data.replace(/X-Mozilla-Keys.+\r\n/, "");*/
 
-		/*if (HeaderToolsLiteObj.prefs.getBoolPref("extensions.hdrtoolslite.add_htl_header")) {
+		/* if (HeaderToolsLiteObj.prefs.getBoolPref("extensions.hdrtoolslite.add_htl_header")) {
 			let now = new Date;
 			let HTLhead = "X-HeaderToolsLite: "+action+" - "+now.toString();
 			HTLhead = HTLhead.replace(/\(.+\)/, "");
@@ -199,124 +199,123 @@ miczColumnsWizard_MsgUtils.listener = {
 				data = data.replace(/\nX-HeaderToolsLite: .+\r\n/,"\n"+HTLhead+"\r\n");
 		}*/
 
-		if(isImap && miczColumnsWizardPrefsUtils.useImapFix){
+		if (isImap && miczColumnsWizardPrefsUtils.useImapFix) {
 			// Some IMAP provider (for ex. GMAIL) doesn't register changes in source if the main headers
 			// are not different from an existing message. To work around this limit, the "Date" field is
 			// modified, if necessary, adding a second to the time (or decreasing a second if second are 59)
 			let newDate = date.replace(/(\d{2}):(\d{2}):(\d{2})/, function (str, p1, p2, p3) {
-				let z = parseInt(p3)+1;
+				let z = parseInt(p3) + 1;
 				if (z > 59) z = 58;
-				if (z < 10) z = "0"+z.toString();
-				return p1+":"+p2+":"+z});
-			data = data.replace(date,newDate);
+				if (z < 10) z = "0" + z.toString();
+				return p1 + ":" + p2 + ":" + z;
+			});
+			data = data.replace(date, newDate);
 		}
 
-		//dump(">>>>>>>>>>>>> miczColumnsWizard_MsgUtils [listener]: data: "+data+"\r\n");
+		// dump(">>>>>>>>>>>>> miczColumnsWizard_MsgUtils [listener]: data: "+data+"\r\n");
 
 		// creates the temporary file, where the modified message body will be stored
-		let tempFile = Components.classes["@mozilla.org/file/directory_service;1"].
-			getService(Components.interfaces.nsIProperties).
-			get("TmpD", Components.interfaces.nsIFile);
+		let tempFile = Cc["@mozilla.org/file/directory_service;1"].
+			getService(Ci.nsIProperties).
+			get("TmpD", Ci.nsIFile);
 		tempFile.append("HT.eml");
-		tempFile.createUnique(0,parseInt("0600", 8));
-		let foStream = Components.classes["@mozilla.org/network/file-output-stream;1"]
-			.createInstance(Components.interfaces.nsIFileOutputStream);
+		tempFile.createUnique(0, parseInt("0600", 8));
+		let foStream = Cc["@mozilla.org/network/file-output-stream;1"]
+			.createInstance(Ci.nsIFileOutputStream);
 		foStream.init(tempFile, 2, 0x200, false); // open as "write only"
-		foStream.write(data,data.length);
+		foStream.write(data, data.length);
 		foStream.close();
 
-		let flags =  miczColumnsWizard_MsgUtils.hdr.flags;
-		let keys =  miczColumnsWizard_MsgUtils.hdr.getStringProperty("keywords");
+		let flags = miczColumnsWizard_MsgUtils.hdr.flags;
+		let keys = miczColumnsWizard_MsgUtils.hdr.getStringProperty("keywords");
 
-		miczColumnsWizard_MsgUtils.list = Components.classes["@mozilla.org/array;1"].createInstance(Components.interfaces.nsIMutableArray);
+		miczColumnsWizard_MsgUtils.list = Cc["@mozilla.org/array;1"].createInstance(Ci.nsIMutableArray);
 		miczColumnsWizard_MsgUtils.list.appendElement(miczColumnsWizard_MsgUtils.hdr, false);
 
 		// this is interesting: nsIMsgFolder.copyFileMessage seems to have a bug on Windows, when
 		// the nsIFile has been already used by foStream (because of Windows lock system?), so we
 		// must initialize another nsIFile object, pointing to the temporary file
-		let fileSpec = Components.classes["@mozilla.org/file/local;1"]
-			.createInstance(Components.interfaces.nsIFile);
+		let fileSpec = Cc["@mozilla.org/file/local;1"]
+			.createInstance(Ci.nsIFile);
 		fileSpec.initWithPath(tempFile.path);
 		let fol = miczColumnsWizard_MsgUtils.hdr.folder;
-		let extService = Components.classes['@mozilla.org/uriloader/external-helper-app-service;1']
-			.getService(Components.interfaces.nsPIExternalAppLauncher)
+		let extService = Cc['@mozilla.org/uriloader/external-helper-app-service;1']
+			.getService(Ci.nsPIExternalAppLauncher);
 		extService.deleteTemporaryFileOnExit(fileSpec); // function's name says all!!!
 		miczColumnsWizard_MsgUtils.noTrash = !miczColumnsWizardPrefsUtils.putOriginalInTrash;
 		// Moved in copyListener.onStopCopy
 		// miczColumnsWizard_MsgUtils.folder.deleteMessages(miczColumnsWizard_MsgUtils.list,null,miczColumnsWizard_MsgUtils.noTrash,true,null,false);
-		let cs = Components.classes["@mozilla.org/messenger/messagecopyservice;1"].getService(Components.interfaces.nsIMsgCopyService);
+		let cs = Cc["@mozilla.org/messenger/messagecopyservice;1"].getService(Ci.nsIMsgCopyService);
 		cs.CopyFileMessage(fileSpec, fol, null, false, flags, keys, miczColumnsWizard_MsgUtils.copyListener, miczColumnsWizard_MsgUtils.msgWindow);
 	},
 
-	onDataAvailable:function(aRequest, aContext, aInputStream, aOffset, aCount){
-		let scriptStream = Components.classes["@mozilla.org/scriptableinputstream;1"].createInstance().QueryInterface(Components.interfaces.nsIScriptableInputStream);
+	onDataAvailable: function (aRequest, aContext, aInputStream, aOffset, aCount) {
+		let scriptStream = Cc["@mozilla.org/scriptableinputstream;1"].createInstance().QueryInterface(Ci.nsIScriptableInputStream);
 		scriptStream.init(aInputStream);
-		miczColumnsWizard_MsgUtils.listener.text+=scriptStream.read(scriptStream.available());
+		miczColumnsWizard_MsgUtils.listener.text += scriptStream.read(scriptStream.available());
 	},
 
 };
 
 // copyFileMessage listener
-miczColumnsWizard_MsgUtils.copyListener={
-	QueryInterface:function(iid){
-		if (iid.equals(Components.interfaces.nsIMsgCopyServiceListener) || iid.equals(Components.interfaces.nsISupports)){
+miczColumnsWizard_MsgUtils.copyListener = {
+	QueryInterface: function (iid) {
+		if (iid.equals(Ci.nsIMsgCopyServiceListener) || iid.equals(Ci.nsISupports)) {
 			return this;
 		}
-		throw Components.results.NS_NOINTERFACE;
+		throw Cr.NS_NOINTERFACE;
 		return 0;
 	},
 
-	GetMessageId:function(messageId){},
-	OnProgress:function(progress, progressMax){},
-	OnStartCopy:function(){},
+	GetMessageId: function (messageId) { },
+	OnProgress: function (progress, progressMax) { },
+	OnStartCopy: function () { },
 
-	OnStopCopy:function(status){
-		if(status == 0){ // copy done
-			miczColumnsWizard_MsgUtils.folder.deleteMessages(miczColumnsWizard_MsgUtils.list,null,miczColumnsWizard_MsgUtils.noTrash,true,null,false);
+	OnStopCopy: function (status) {
+		if (status === 0) { // copy done
+			miczColumnsWizard_MsgUtils.folder.deleteMessages(miczColumnsWizard_MsgUtils.list, null, miczColumnsWizard_MsgUtils.noTrash, true, null, false);
 		}
 	},
 
-	SetMessageKey:function(key){
+	SetMessageKey: function (key) {
 		// at this point, the message is already stored in local folders, but not yet in remote folders,
 		// so for remote folders we use a folderListener
-		//miczLogger.log('miczColumnsWizard_MsgUtils.SetMessageKey START');
-		if (miczColumnsWizard_MsgUtils.folder.server.type == "imap" || miczColumnsWizard_MsgUtils.folder.server.type == "news") {
-			//miczLogger.log('miczColumnsWizard_MsgUtils.SetMessageKey IMAP');
-			Components.classes["@mozilla.org/messenger/services/session;1"]
-					.getService(Components.interfaces.nsIMsgMailSession)
-					.AddFolderListener(miczColumnsWizard_MsgUtils.folderListener, Components.interfaces.nsIFolderListener.all);
+		// miczLogger.log('miczColumnsWizard_MsgUtils.SetMessageKey START');
+		if (miczColumnsWizard_MsgUtils.folder.server.type === "imap" || miczColumnsWizard_MsgUtils.folder.server.type === "news") {
+			// miczLogger.log('miczColumnsWizard_MsgUtils.SetMessageKey IMAP');
+			Cc["@mozilla.org/messenger/services/session;1"]
+				.getService(Ci.nsIMsgMailSession)
+				.AddFolderListener(miczColumnsWizard_MsgUtils.folderListener, Ci.nsIFolderListener.all);
 			miczColumnsWizard_MsgUtils.folderListener.key = key;
 			miczColumnsWizard_MsgUtils.folderListener.URI = miczColumnsWizard_MsgUtils.folder.URI;
+		} else {
+			// miczLogger.log('miczColumnsWizard_MsgUtils.SetMessageKey NOT IMAP');
+			miczColumnsWizard_MsgUtils.win.setTimeout(function () { miczColumnsWizard_MsgUtils.postActions(key); }, 500);
 		}
-		else
-		{
-			//miczLogger.log('miczColumnsWizard_MsgUtils.SetMessageKey NOT IMAP');
-			miczColumnsWizard_MsgUtils.win.setTimeout(function(){miczColumnsWizard_MsgUtils.postActions(key);},500);
-		}
-	}
+	},
 };
 
 // used just for remote folders
-miczColumnsWizard_MsgUtils.folderListener={
-	OnItemAdded:function(parentItem, item, view){
-		//miczLogger.log('miczColumnsWizard_MsgUtils.folderListener.OnItemAdded START');
+miczColumnsWizard_MsgUtils.folderListener = {
+	OnItemAdded: function (parentItem, item, view) {
+		// miczLogger.log('miczColumnsWizard_MsgUtils.folderListener.OnItemAdded START');
 		let hdr = null;
-		try{
-			hdr = item.QueryInterface(Components.interfaces.nsIMsgDBHdr);
-		}catch(e){return;}
-		if (miczColumnsWizard_MsgUtils.folderListener.key == hdr.messageKey && miczColumnsWizard_MsgUtils.folderListener.URI == hdr.folder.URI){
-			//miczLogger.log('miczColumnsWizard_MsgUtils.folderListener.OnItemAdded DOING POSTACTION');
+		try {
+			hdr = item.QueryInterface(Ci.nsIMsgDBHdr);
+		} catch (e) { return; }
+		if (miczColumnsWizard_MsgUtils.folderListener.key === hdr.messageKey && miczColumnsWizard_MsgUtils.folderListener.URI === hdr.folder.URI) {
+			// miczLogger.log('miczColumnsWizard_MsgUtils.folderListener.OnItemAdded DOING POSTACTION');
 			miczColumnsWizard_MsgUtils.postActions(miczColumnsWizard_MsgUtils.folderListener.key);
 			// we don't need anymore the folderListener
-			Components.classes["@mozilla.org/messenger/services/session;1"].getService(Components.interfaces.nsIMsgMailSession).RemoveFolderListener(miczColumnsWizard_MsgUtils.folderListener);
+			Cc["@mozilla.org/messenger/services/session;1"].getService(Ci.nsIMsgMailSession).RemoveFolderListener(miczColumnsWizard_MsgUtils.folderListener);
 		}
 	},
 
-	OnItemRemoved:function(parentItem, item, view){},
-	OnItemPropertyChanged:function(item, property, oldValue, newValue){},
-	OnItemIntPropertyChanged:function(item, property, oldValue, newValue){},
-	OnItemBoolPropertyChanged:function(item, property, oldValue, newValue){},
-	OnItemUnicharPropertyChanged:function(item, property, oldValue, newValue){},
-	OnItemPropertyFlagChanged:function(item, property, oldFlag, newFlag){},
-	OnItemEvent:function(folder, event){},
+	OnItemRemoved: function (parentItem, item, view) { },
+	OnItemPropertyChanged: function (item, property, oldValue, newValue) { },
+	OnItemIntPropertyChanged: function (item, property, oldValue, newValue) { },
+	OnItemBoolPropertyChanged: function (item, property, oldValue, newValue) { },
+	OnItemUnicharPropertyChanged: function (item, property, oldValue, newValue) { },
+	OnItemPropertyFlagChanged: function (item, property, oldFlag, newFlag) { },
+	OnItemEvent: function (folder, event) { },
 };

--- a/src/chrome/content/mzcw-msgutils.jsm
+++ b/src/chrome/content/mzcw-msgutils.jsm
@@ -106,6 +106,7 @@ var miczColumnsWizard_MsgUtils = {
 		// set labels if needed
 		// miczLogger.log('miczColumnsWizard_MsgUtils.postActions SETTING LABELS');
 		// miczLogger.log('miczColumnsWizard_MsgUtils.postActions miczColumnsWizard_MsgUtils.tags: '+miczColumnsWizard_MsgUtils.tags.join(" "));
+		// Check
 		miczColumnsWizard_MsgUtils.folder.addKeywordsToMessages(toXPCOMArray([hdr], Ci.nsIMutableArray), miczColumnsWizard_MsgUtils.tags.join(" "));
 		// miczLogger.log('miczColumnsWizard_MsgUtils.postActions LABELS SET');
 	},

--- a/src/chrome/content/mzcw-overlay.js
+++ b/src/chrome/content/mzcw-overlay.js
@@ -145,7 +145,7 @@ var miczColumnsWizard = {
 
 	removeCustomColumn: function (coltype, ObserverService) {
 		let element = document.getElementById(coltype + "Col_cw");
-		if (element) element.parentNode.removeChild(element);
+		if (element) element.remove();
 
 		// dump(">>>>>>>>>>>>> miczColumnsWizard->removeCustomColumn: [coltype] "+coltype+"\r\n");
 		// DbObserver Managing

--- a/src/chrome/content/mzcw-overlay.js
+++ b/src/chrome/content/mzcw-overlay.js
@@ -1,4 +1,5 @@
 "use strict";
+
 ChromeUtils.import("chrome://columnswizard/content/mzcw-prefsutils.jsm");
 ChromeUtils.import("chrome://columnswizard/content/mzcw-customcolsmodutils.jsm");
 ChromeUtils.import("chrome://columnswizard/content/mzcw-msgutils.jsm");
@@ -7,40 +8,40 @@ ChromeUtils.import("resource://columnswizard/miczLogger.jsm");
 
 var miczColumnsWizard = {
 
-  //Conversation Tab Columns
-  showLocation: true,
-  showAccount: false,
-  showAttachment: false,
-  showRecipient: false,
+	// Conversation Tab Columns
+	showLocation: true,
+	showAccount: false,
+	showAttachment: false,
+	showRecipient: false,
 
-  //Custom Columns
-  CustColPref:{},
+	// Custom Columns
+	CustColPref: {},
 
-	init: function(){
-		
-		miczLogger.setLogger(true,miczColumnsWizardPrefsUtils.isDebug);
+	init: function () {
 
-		if(miczColumnsWizardPrefsUtils.firstRun){		//adding toolbar button at first run
+		miczLogger.setLogger(true, miczColumnsWizardPrefsUtils.isDebug);
+
+		if (miczColumnsWizardPrefsUtils.firstRun) {		// adding toolbar button at first run
 			miczColumnsWizardPrefsUtils.firstRunDone();
 			miczColumnsWizard.addToolbarButton();
 		}
 
-		let ObserverService = Components.classes["@mozilla.org/observer-service;1"].getService(Components.interfaces.nsIObserverService);
+		let ObserverService = Cc["@mozilla.org/observer-service;1"].getService(Cc.nsIObserverService);
 
 		miczColumnsWizard.addNewCustColObserver(ObserverService);
 		miczColumnsWizard.deleteCustColObserver(ObserverService);
 		miczColumnsWizard.updateCustColObserver(ObserverService);
 		miczColumnsWizard.updateHeaderEditingMenuObserver(ObserverService);
 
-		//Adding custom columns
-		miczColumnsWizard.CustColPref=miczColumnsWizard_CustCols.loadCustCols();
+		// Adding custom columns
+		miczColumnsWizard.CustColPref = miczColumnsWizard_CustCols.loadCustCols();
 
 		for (let index in miczColumnsWizard.CustColPref) {
 			miczColumnsWizard.addDbObserver(miczColumnsWizard.CustColPref[index]);
 		}
 
 		for (let index in miczColumnsWizard.CustColPref) {
-		  miczColumnsWizard.custColsActivation(miczColumnsWizard.CustColPref[index],ObserverService);
+			miczColumnsWizard.custColsActivation(miczColumnsWizard.CustColPref[index], ObserverService);
 		}
 
 		miczColumnsWizard.watchFolders();
@@ -50,384 +51,385 @@ var miczColumnsWizard = {
 		miczColumnsWizard.addCWResetMenu(current_tab);
 
 		this.initialized = true;
-		//Conversation Tab add columns - delayed
-		setTimeout(function() { miczColumnsWizard.initDelayed(); }, 750);
-		miczLogger.log("ColumnsWizard loaded...",0);
+		// Conversation Tab add columns - delayed
+		setTimeout(function () { miczColumnsWizard.initDelayed(); }, 750);
+		miczLogger.log("ColumnsWizard loaded...", 0);
 	},
 
-	initDelayed:function(){
-		try{
-			//Conversation Tab add columns
-		let tabmail = document.getElementById("tabmail");
-		let monitor = {
-		  onTabTitleChanged:function(tab){},
-		  onTabSwitched: miczColumnsWizard.addCWResetMenu, //this.showColumns,
-		  //onTabRestored:function(tab){},
-		  onTabOpened: this.showColumns,
+	initDelayed: function () {
+		try {
+			// Conversation Tab add columns
+			let tabmail = document.getElementById("tabmail");
+			let monitor = {
+				onTabTitleChanged: function (tab) { },
+				onTabSwitched: miczColumnsWizard.addCWResetMenu, // this.showColumns,
+				// onTabRestored:function(tab){},
+				onTabOpened: this.showColumns,
+			};
+			tabmail.registerTabMonitor(monitor);
+		} catch (e) {
+			alert("No tabContainer available! " + e);
+		}
+	},
+
+	addNewCustColObserver: function (ObserverService) {
+		let CustColObserver = {
+			observe: function (aSubject, aTopic, aData) {
+				// dump(">>>>>>>>>>>>> miczColumnsWizard->CustColObserver: [aSubject] "+aData+"\r\n");
+				miczColumnsWizard.addDbObserver(JSON.parse(aData));
+			},
 		};
-		tabmail.registerTabMonitor(monitor);
-		}catch(e){
-		  alert("No tabContainer available! " + e);
-		}
+		ObserverService.addObserver(CustColObserver, "CW-newCustomColumn", false);
 	},
 
-	addNewCustColObserver:function(ObserverService){
+	deleteCustColObserver: function (ObserverService) {
 		let CustColObserver = {
-			observe: function(aSubject,aTopic,aData){
-				//dump(">>>>>>>>>>>>> miczColumnsWizard->CustColObserver: [aSubject] "+aData+"\r\n");
-    			miczColumnsWizard.addDbObserver(JSON.parse(aData));
-  			}
-		}
-		ObserverService.addObserver(CustColObserver,"CW-newCustomColumn",false);
-	},
-
-	deleteCustColObserver:function(ObserverService){
-		let CustColObserver = {
-			observe: function(aSubject,aTopic,aData){
-				//dump(">>>>>>>>>>>>> miczColumnsWizard->CustColObserver: [aSubject] "+aData+"\r\n");
-				let ObserverService = Components.classes["@mozilla.org/observer-service;1"].getService(Components.interfaces.nsIObserverService);
-    			miczColumnsWizard_CustCols.removeCustomColumn(aData,ObserverService);
+			observe: function (aSubject, aTopic, aData) {
+				// dump(">>>>>>>>>>>>> miczColumnsWizard->CustColObserver: [aSubject] "+aData+"\r\n");
+				let ObserverService = Cc["@mozilla.org/observer-service;1"].getService(Cc.nsIObserverService);
+				miczColumnsWizard_CustCols.removeCustomColumn(aData, ObserverService);
 				miczColumnsWizard_CustCols.deleteCustCol(aData);
-  			}
-		}
-		ObserverService.addObserver(CustColObserver,"CW-deleteCustomColumn",false);
+			},
+		};
+		ObserverService.addObserver(CustColObserver, "CW-deleteCustomColumn", false);
 	},
 
-	updateCustColObserver:function(ObserverService){
+	updateCustColObserver: function (ObserverService) {
 		let CustColObserver = {
-			observe: function(aSubject,aTopic,aData){
-				//dump(">>>>>>>>>>>>> miczColumnsWizard->CustColObserver: [aSubject] "+aData+"\r\n");
-				let ObserverService = Components.classes["@mozilla.org/observer-service;1"].getService(Components.interfaces.nsIObserverService);
-    			//update cust col info in the message list
-    			miczColumnsWizard_CustCols.updateCustomColumn(JSON.parse(aData));
-  			}
-		}
-		ObserverService.addObserver(CustColObserver,"CW-updateCustomColumn",false);
+			observe: function (aSubject, aTopic, aData) {
+				// dump(">>>>>>>>>>>>> miczColumnsWizard->CustColObserver: [aSubject] "+aData+"\r\n");
+				let ObserverService = Cc["@mozilla.org/observer-service;1"].getService(Cc.nsIObserverService);
+				// update cust col info in the message list
+				miczColumnsWizard_CustCols.updateCustomColumn(JSON.parse(aData));
+			},
+		};
+		ObserverService.addObserver(CustColObserver, "CW-updateCustomColumn", false);
 	},
 
-	addDbObserver:function(currcol){
-		//Create all the needed DbObservers
-		  //dump(">>>>>>>>>>>>> miczColumnsWizard->CreateDbObserver: [index] "+currcol.index+"\r\n");
-		  //It's needed to to this, to avoid writing each miczColumnsWizard_CustCols.CreateDbObserver_COLNAME by hand, because we need to pass the index var inside the observe function definition.
-		  let obfunction = function(aMsgFolder,aTopic,aData){miczColumnsWizard_CustCols.addCustomColumnHandler(currcol.index);};
-		  miczColumnsWizard_CustCols.CreateDbObserver[currcol.index]={observe: obfunction};
-		  //Create all the needed DbObserver - END
+	addDbObserver: function (currcol) {
+		// Create all the needed DbObservers
+		// dump(">>>>>>>>>>>>> miczColumnsWizard->CreateDbObserver: [index] "+currcol.index+"\r\n");
+		// It's needed to to this, to avoid writing each miczColumnsWizard_CustCols.CreateDbObserver_COLNAME by hand, because we need to pass the index var inside the observe function definition.
+		let obfunction = function (aMsgFolder, aTopic, aData) { miczColumnsWizard_CustCols.addCustomColumnHandler(currcol.index); };
+		miczColumnsWizard_CustCols.CreateDbObserver[currcol.index] = { observe: obfunction };
+		// Create all the needed DbObserver - END
 
-		 //Implement all the needed ColumnHandlers
-		 let sortfunc = function(hdr) { return hdr.getStringProperty(currcol.dbHeader);};
-		 let sortfunc_number = function(hdr) {	//max unsigned long 4294967296-1
-									let output=hdr.getStringProperty(currcol.dbHeader)*1000;
-									output+=1000000000;
-									//miczLogger.log(">>>>>>>>>>>>> miczColumnsWizard->CreateDbObserver: [output original] "+hdr.getStringProperty(currcol.dbHeader)+"\r\n");
-									//miczLogger.log(">>>>>>>>>>>>> miczColumnsWizard->CreateDbObserver: [output] "+JSON.stringify(output)+"\r\n");
-									return output;
-			 					};
-		 let is_stringfunc = function(hdr) { return !currcol.sortnumber;};
-		 let celltextfunc = function(row,col){let hdr = gDBView.getMsgHdrAt(row);let output=hdr.getStringProperty(currcol.dbHeader);
-		 											//miczLogger.log(">>>>>>>>>>>>> miczColumnsWizard->CreateDbObserver: [celltextfunc] "+JSON.stringify(output)+"\r\n");
-		 											return output;
-		 										};
-//dump(">>>>>>>>>>>>> miczColumnsWizard->CreateDbObserver: [currcol] "+JSON.stringify(currcol)+"\r\n");
-		  miczColumnsWizard_CustCols["columnHandler_"+currcol.index]={
-			getCellText:         celltextfunc,
+		// Implement all the needed ColumnHandlers
+		let sortfunc = function (hdr) { return hdr.getStringProperty(currcol.dbHeader); };
+		let sortfunc_number = function (hdr) {	// max unsigned long 4294967296-1
+			let output = hdr.getStringProperty(currcol.dbHeader) * 1000;
+			output += 1000000000;
+			// miczLogger.log(">>>>>>>>>>>>> miczColumnsWizard->CreateDbObserver: [output original] "+hdr.getStringProperty(currcol.dbHeader)+"\r\n");
+			// miczLogger.log(">>>>>>>>>>>>> miczColumnsWizard->CreateDbObserver: [output] "+JSON.stringify(output)+"\r\n");
+			return output;
+		};
+		let is_stringfunc = function (hdr) { return !currcol.sortnumber; };
+		let celltextfunc = function (row, col) {
+			let hdr = gDBView.getMsgHdrAt(row); let output = hdr.getStringProperty(currcol.dbHeader);
+			// miczLogger.log(">>>>>>>>>>>>> miczColumnsWizard->CreateDbObserver: [celltextfunc] "+JSON.stringify(output)+"\r\n");
+			return output;
+		};
+		// dump(">>>>>>>>>>>>> miczColumnsWizard->CreateDbObserver: [currcol] "+JSON.stringify(currcol)+"\r\n");
+		miczColumnsWizard_CustCols["columnHandler_" + currcol.index] = {
+			getCellText: celltextfunc,
 			getSortStringForRow: sortfunc,
-			isString:            is_stringfunc,
-			getCellProperties:   function(row, col, props){},
-			getRowProperties:    function(row, props){},
-			getImageSrc:         function(row, col) {return null;},
-			getSortLongForRow:   sortfunc_number
-		  };
-		 //Implement all the needed ColumnHandlers - END
+			isString: is_stringfunc,
+			getCellProperties: function (row, col, props) { },
+			getRowProperties: function (row, props) { },
+			getImageSrc: function (row, col) { return null; },
+			getSortLongForRow: sortfunc_number,
+		};
+		// Implement all the needed ColumnHandlers - END
 	},
 
-    removeCustomColumn: function(coltype,ObserverService){
-      let element = document.getElementById(coltype+"Col_cw");
-      if(element) element.parentNode.removeChild(element);
+	removeCustomColumn: function (coltype, ObserverService) {
+		let element = document.getElementById(coltype + "Col_cw");
+		if (element) element.parentNode.removeChild(element);
 
-      //dump(">>>>>>>>>>>>> miczColumnsWizard->removeCustomColumn: [coltype] "+coltype+"\r\n");
-      //DbObserver Managing
-      try{
-      	ObserverService.removeObserver(miczColumnsWizard_CustCols.CreateDbObserver[coltype], "MsgCreateDBView");
-      }catch(ex){
-		//No observer found
-	  }
-    },
+		// dump(">>>>>>>>>>>>> miczColumnsWizard->removeCustomColumn: [coltype] "+coltype+"\r\n");
+		// DbObserver Managing
+		try {
+			ObserverService.removeObserver(miczColumnsWizard_CustCols.CreateDbObserver[coltype], "MsgCreateDBView");
+		} catch (ex) {
+			// No observer found
+		}
+	},
 
-	custColsActivation:function(element,ObserverService){
-	//dump(">>>>>>>>>>>>> miczColumnsWizard: [element|index] "+element.Pref+"|"+index+"\r\n");
-		if(element.enabled===true){
-			miczColumnsWizard_CustCols.addCustomColumn(element,ObserverService);
-			if(element.isCustom!=false){
+	custColsActivation: function (element, ObserverService) {
+		// dump(">>>>>>>>>>>>> miczColumnsWizard: [element|index] "+element.Pref+"|"+index+"\r\n");
+		if (element.enabled === true) {
+			miczColumnsWizard_CustCols.addCustomColumn(element, ObserverService);
+			if (element.isCustom !== false) {
 				miczColumnsWizard.activateCustomDBHeader(element.dbHeader);
 			}
 		}
 	},
 
-  activateCustomDBHeader:function(newHeader){
-    //dump(">>>>>>>>>>>>> miczColumnsWizard: [customDBHeaders] "+newHeader+"\r\n");
-    //let prefService = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefBranch);
-    //let currentHeaders = prefService.getCharPref("mailnews.customDBHeaders");
-    let currentHeaders = miczColumnsWizardPrefsUtils.getCharPref("mailnews.customDBHeaders");
-    let re = new RegExp("(^| )"+newHeader+"( |$)","i");
-    if (currentHeaders.search(re) < 0) {
-      currentHeaders = currentHeaders + " "+newHeader;
-      miczColumnsWizardPrefsUtils.setCharPref("mailnews.customDBHeaders", currentHeaders.trim());
-      //dump(">>>>>>>>>>>>> miczColumnsWizard: [customDBHeaders->Updating] "+newHeader+"\r\n");
-    }
-  },
-
-  deactivateCustomDBHeader:function(newHeader){
-    //dump(">>>>>>>>>>>>> miczColumnsWizard: [deactivate customDBHeaders] "+newHeader+"\r\n");
-    //let prefService = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefBranch);
-    //let currentHeaders = prefService.getCharPref("mailnews.customDBHeaders");
-    let currentHeaders = miczColumnsWizardPrefsUtils.getCharPref("mailnews.customDBHeaders");
-    let re = new RegExp("(^| )"+newHeader+"( |$)","i");
-    currentHeaders=currentHeaders.replace(re," ");
-    miczColumnsWizardPrefsUtils.setCharPref("mailnews.customDBHeaders", currentHeaders);
-    //dump(">>>>>>>>>>>>> miczColumnsWizard: [deactivate customDBHeaders->Updating] "+newHeader+"\r\n");
-  },
-
-  showColumns: function(tab){
-    //let prefs = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
-    //prefs = prefs.getBranch("extensions.ColumnsWizard.");
-    this.showLocation = miczColumnsWizardPrefsUtils.getBoolPref_CW("ShowLocation");
-    this.showAccount = miczColumnsWizardPrefsUtils.getBoolPref_CW("ShowAccount");
-    this.showAttachment = miczColumnsWizardPrefsUtils.getBoolPref_CW("ShowAttachment");
-    this.showRecipient = miczColumnsWizardPrefsUtils.getBoolPref_CW("ShowRecipient");
-
-	  if(tab.mode.name=='glodaList'){
-	  if(this.showLocation){ //show location column
-      let loccv = document.getElementById("locationCol");
-      if(loccv) loccv.setAttribute("hidden", "false");
-     }
-     if(this.showAccount){ //show account column
-      let accountcv = document.getElementById("accountCol");
-      if(accountcv) accountcv.setAttribute("hidden", "false");
-     }
-     if(this.showAttachment){ //show attachment column
-      let attachcv = document.getElementById("attachmentCol");
-      if(attachcv) attachcv.setAttribute("hidden", "false");
-     }
-     if(this.showRecipient){ //show recipient column
-      let recipientcv = document.getElementById("recipientCol");
-      if(recipientcv) recipientcv.setAttribute("hidden", "false");
-     }
-    }
-    //dump(">>>>>>>>>>>>> miczColumnsWizard: [tab folder mode] "+tab.mode.name+" \r\n");
-    miczColumnsWizard.addCWResetMenu(tab);
-  },
-
-  addCWResetMenu:function(tab){
-	if(tab.mode.name=='folder'){
-		var cw_colmenubind=document.getAnonymousElementByAttribute(document.getElementById('threadCols'),'class','treecol-image');
-		//dump(">>>>>>>>>>>>> miczColumnsWizard: [addCWResetMenu] tab.cw_colmenubind.command "+cw_colmenubind.oncommand+"\r\n");
-		if (!cw_colmenubind.cw_original_buildPopup){
-			cw_colmenubind.cw_original_buildPopup=cw_colmenubind.buildPopup;
-			//dump(">>>>>>>>>>>>> miczColumnsWizard: [addCWResetMenu] tab.cw_colmenubind.buildPopup "+cw_colmenubind.buildPopup+"\r\n");
-			//dump(">>>>>>>>>>>>> miczColumnsWizard: [addCWResetMenu] FIRST TIME\r\n");
-			cw_colmenubind.buildPopup=function(aPopup){ // buildPopup wrapper function START
-				//dump(">>>>>>>>>>>>> miczColumnsWizard: [addCWResetMenu] "+this.parentNode.parentNode.id+"\r\n");
-				//Remove the columns' line... the popupmenu is built again every time from the original function...
-				if(aPopup.childNodes.length >= 5){
-					while (aPopup.childNodes.length > 5){
-						aPopup.firstChild.remove();
-					}
-					//... now remove the resetMenuCW and saveDefaultMenuCW items...
-					aPopup.removeChild(aPopup.childNodes[2]);
-					aPopup.removeChild(aPopup.childNodes[2]);
-				}
-				//check if we're using the colcw default for new folders
-				//let prefsc = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
-				//let prefs = prefsc.getBranch("extensions.ColumnsWizard.DefaultColsList.");
-				//let cw_active=prefs.getBoolPref("active");
-				let cw_active=miczColumnsWizardPrefsUtils.defaultColsListActive;
-
-				let strBundleCW = Components.classes["@mozilla.org/intl/stringbundle;1"].getService(Components.interfaces.nsIStringBundleService);
-				let _bundleCW = strBundleCW.createBundle("chrome://columnswizard/locale/overlay.properties");
-
-				aPopup.childNodes[1].setAttribute('hidden',cw_active?'true':'false');
-
-				cw_colmenubind.cw_original_buildPopup(aPopup);
-
-				//Add saveDefaultMenuCW element
-				let saveDefaultMenuCW = document.createElement("menuitem");
-				saveDefaultMenuCW.setAttribute('label',_bundleCW.GetStringFromName("ColumnsWizardNFCols.saveDefault"));
-				saveDefaultMenuCW.setAttribute('hidden',cw_active?'false':'true');
-				//we do this to escape the command xbl event handler
-				saveDefaultMenuCW.setAttribute("colindex", "-1");
-				saveDefaultMenuCW.setAttribute("class", "menuitem-iconic");
-				saveDefaultMenuCW.setAttribute("image","chrome://columnswizard/skin/ico/saveDefaultMenuCW.png");
-				saveDefaultMenuCW.onclick=miczColumnsWizard.addCWSaveDefaultMenu_OnClick;
-				aPopup.insertBefore(saveDefaultMenuCW,aPopup.lastChild);
-
-				//Add resetMenuCw element
-				let resetMenuCW = document.createElement("menuitem");
-				resetMenuCW.setAttribute('label',_bundleCW.GetStringFromName("ColumnsWizardNFCols.resetMenu"));
-				resetMenuCW.setAttribute('hidden',cw_active?'false':'true');
-				//we do this to escape the command xbl event handler
-				resetMenuCW.setAttribute("colindex", "-1");
-				resetMenuCW.setAttribute("class", "menuitem-iconic");
-				resetMenuCW.setAttribute("image","chrome://columnswizard/skin/ico/resetMenuCW.png");
-				resetMenuCW.onclick=miczColumnsWizard.addCWResetMenu_OnClick;
-				aPopup.insertBefore(resetMenuCW,aPopup.lastChild);
-
-			}	// buildPopup wrapper function END
+	activateCustomDBHeader: function (newHeader) {
+		// dump(">>>>>>>>>>>>> miczColumnsWizard: [customDBHeaders] "+newHeader+"\r\n");
+		// let prefService = Cc["@mozilla.org/preferences-service;1"].getService(Cc.nsIPrefBranch);
+		// let currentHeaders = prefService.getCharPref("mailnews.customDBHeaders");
+		let currentHeaders = miczColumnsWizardPrefsUtils.getCharPref("mailnews.customDBHeaders");
+		let re = new RegExp("(^| )" + newHeader + "( |$)", "i");
+		if (currentHeaders.search(re) < 0) {
+			currentHeaders = currentHeaders + " " + newHeader;
+			miczColumnsWizardPrefsUtils.setCharPref("mailnews.customDBHeaders", currentHeaders.trim());
+			// dump(">>>>>>>>>>>>> miczColumnsWizard: [customDBHeaders->Updating] "+newHeader+"\r\n");
 		}
-	}
-  },
+	},
 
-    addCWSaveDefaultMenu_OnClick:function(event){
-		//dump(">>>>>>>>>>>>> miczColumnsWizard: [addCWResetMenu_OnClick] test "+event.target.parentNode.getEventHandler('oncommand')+"\r\n");
-		let strBundleCW = Components.classes["@mozilla.org/intl/stringbundle;1"].getService(Components.interfaces.nsIStringBundleService);
+	deactivateCustomDBHeader: function (newHeader) {
+		// dump(">>>>>>>>>>>>> miczColumnsWizard: [deactivate customDBHeaders] "+newHeader+"\r\n");
+		// let prefService = Cc["@mozilla.org/preferences-service;1"].getService(Cc.nsIPrefBranch);
+		// let currentHeaders = prefService.getCharPref("mailnews.customDBHeaders");
+		let currentHeaders = miczColumnsWizardPrefsUtils.getCharPref("mailnews.customDBHeaders");
+		let re = new RegExp("(^| )" + newHeader + "( |$)", "i");
+		currentHeaders = currentHeaders.replace(re, " ");
+		miczColumnsWizardPrefsUtils.setCharPref("mailnews.customDBHeaders", currentHeaders);
+		// dump(">>>>>>>>>>>>> miczColumnsWizard: [deactivate customDBHeaders->Updating] "+newHeader+"\r\n");
+	},
+
+	showColumns: function (tab) {
+		// let prefs = Cc["@mozilla.org/preferences-service;1"].getService(Cc.nsIPrefService);
+		// prefs = prefs.getBranch("extensions.ColumnsWizard.");
+		this.showLocation = miczColumnsWizardPrefsUtils.getBoolPref_CW("ShowLocation");
+		this.showAccount = miczColumnsWizardPrefsUtils.getBoolPref_CW("ShowAccount");
+		this.showAttachment = miczColumnsWizardPrefsUtils.getBoolPref_CW("ShowAttachment");
+		this.showRecipient = miczColumnsWizardPrefsUtils.getBoolPref_CW("ShowRecipient");
+
+		if (tab.mode.name === 'glodaList') {
+			if (this.showLocation) { // show location column
+				let loccv = document.getElementById("locationCol");
+				if (loccv) loccv.setAttribute("hidden", "false");
+			}
+			if (this.showAccount) { // show account column
+				let accountcv = document.getElementById("accountCol");
+				if (accountcv) accountcv.setAttribute("hidden", "false");
+			}
+			if (this.showAttachment) { // show attachment column
+				let attachcv = document.getElementById("attachmentCol");
+				if (attachcv) attachcv.setAttribute("hidden", "false");
+			}
+			if (this.showRecipient) { // show recipient column
+				let recipientcv = document.getElementById("recipientCol");
+				if (recipientcv) recipientcv.setAttribute("hidden", "false");
+			}
+		}
+		// dump(">>>>>>>>>>>>> miczColumnsWizard: [tab folder mode] "+tab.mode.name+" \r\n");
+		miczColumnsWizard.addCWResetMenu(tab);
+	},
+
+	addCWResetMenu: function (tab) {
+		if (tab.mode.name === 'folder') {
+			var cw_colmenubind = document.getAnonymousElementByAttribute(document.getElementById('threadCols'), 'class', 'treecol-image');
+			// dump(">>>>>>>>>>>>> miczColumnsWizard: [addCWResetMenu] tab.cw_colmenubind.command "+cw_colmenubind.oncommand+"\r\n");
+			if (!cw_colmenubind.cw_original_buildPopup) {
+				cw_colmenubind.cw_original_buildPopup = cw_colmenubind.buildPopup;
+				// dump(">>>>>>>>>>>>> miczColumnsWizard: [addCWResetMenu] tab.cw_colmenubind.buildPopup "+cw_colmenubind.buildPopup+"\r\n");
+				// dump(">>>>>>>>>>>>> miczColumnsWizard: [addCWResetMenu] FIRST TIME\r\n");
+				cw_colmenubind.buildPopup = function (aPopup) { // buildPopup wrapper function START
+					// dump(">>>>>>>>>>>>> miczColumnsWizard: [addCWResetMenu] "+this.parentNode.parentNode.id+"\r\n");
+					// Remove the columns' line... the popupmenu is built again every time from the original function...
+					if (aPopup.childNodes.length >= 5) {
+						while (aPopup.childNodes.length > 5) {
+							aPopup.firstChild.remove();
+						}
+						// ... now remove the resetMenuCW and saveDefaultMenuCW items...
+						aPopup.removeChild(aPopup.childNodes[2]);
+						aPopup.removeChild(aPopup.childNodes[2]);
+					}
+					// check if we're using the colcw default for new folders
+					// let prefsc = Cc["@mozilla.org/preferences-service;1"].getService(Cc.nsIPrefService);
+					// let prefs = prefsc.getBranch("extensions.ColumnsWizard.DefaultColsList.");
+					// let cw_active=prefs.getBoolPref("active");
+					let cw_active = miczColumnsWizardPrefsUtils.defaultColsListActive;
+
+					let strBundleCW = Cc["@mozilla.org/intl/stringbundle;1"].getService(Cc.nsIStringBundleService);
+					let _bundleCW = strBundleCW.createBundle("chrome://columnswizard/locale/overlay.properties");
+
+					aPopup.childNodes[1].setAttribute('hidden', cw_active ? 'true' : 'false');
+
+					cw_colmenubind.cw_original_buildPopup(aPopup);
+
+					// Add saveDefaultMenuCW element
+					let saveDefaultMenuCW = document.createElement("menuitem");
+					saveDefaultMenuCW.setAttribute('label', _bundleCW.GetStringFromName("ColumnsWizardNFCols.saveDefault"));
+					saveDefaultMenuCW.setAttribute('hidden', cw_active ? 'false' : 'true');
+					// we do this to escape the command xbl event handler
+					saveDefaultMenuCW.setAttribute("colindex", "-1");
+					saveDefaultMenuCW.setAttribute("class", "menuitem-iconic");
+					saveDefaultMenuCW.setAttribute("image", "chrome://columnswizard/skin/ico/saveDefaultMenuCW.png");
+					saveDefaultMenuCW.onclick = miczColumnsWizard.addCWSaveDefaultMenu_OnClick;
+					aPopup.insertBefore(saveDefaultMenuCW, aPopup.lastChild);
+
+					// Add resetMenuCw element
+					let resetMenuCW = document.createElement("menuitem");
+					resetMenuCW.setAttribute('label', _bundleCW.GetStringFromName("ColumnsWizardNFCols.resetMenu"));
+					resetMenuCW.setAttribute('hidden', cw_active ? 'false' : 'true');
+					// we do this to escape the command xbl event handler
+					resetMenuCW.setAttribute("colindex", "-1");
+					resetMenuCW.setAttribute("class", "menuitem-iconic");
+					resetMenuCW.setAttribute("image", "chrome://columnswizard/skin/ico/resetMenuCW.png");
+					resetMenuCW.onclick = miczColumnsWizard.addCWResetMenu_OnClick;
+					aPopup.insertBefore(resetMenuCW, aPopup.lastChild);
+
+				};	// buildPopup wrapper function END
+			}
+		}
+	},
+
+	addCWSaveDefaultMenu_OnClick: function (event) {
+		// dump(">>>>>>>>>>>>> miczColumnsWizard: [addCWResetMenu_OnClick] test "+event.target.parentNode.getEventHandler('oncommand')+"\r\n");
+		let strBundleCW = Cc["@mozilla.org/intl/stringbundle;1"].getService(Cc.nsIStringBundleService);
 		let _bundleCW = strBundleCW.createBundle("chrome://columnswizard/locale/overlay.properties");
-		let promptService = Components.classes["@mozilla.org/embedcomp/prompt-service;1"].getService(Components.interfaces.nsIPromptService);
-		let title_msg=_bundleCW.GetStringFromName("ColumnsWizardNFCols.saveDefault");
-		let text_msg=_bundleCW.GetStringFromName("ColumnsWizard.saveDefault_OnClick_text");
-		if(!promptService.confirm(null,title_msg,text_msg))return;
+		let promptService = Cc["@mozilla.org/embedcomp/prompt-service;1"].getService(Cc.nsIPromptService);
+		let title_msg = _bundleCW.GetStringFromName("ColumnsWizardNFCols.saveDefault");
+		let text_msg = _bundleCW.GetStringFromName("ColumnsWizard.saveDefault_OnClick_text");
+		if (!promptService.confirm(null, title_msg, text_msg)) return;
 		let columnStates = gFolderDisplay.getColumnStates();
-		//let prefsc = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
-		//let prefs = prefsc.getBranch("extensions.ColumnsWizard.");
-		//prefs.setCharPref("DefaultColsList",JSON.stringify(columnStates));
-		miczColumnsWizardPrefsUtils.setCharPref_CW("DefaultColsList",JSON.stringify(columnStates));
+		// let prefsc = Cc["@mozilla.org/preferences-service;1"].getService(Cc.nsIPrefService);
+		// let prefs = prefsc.getBranch("extensions.ColumnsWizard.");
+		// prefs.setCharPref("DefaultColsList",JSON.stringify(columnStates));
+		miczColumnsWizardPrefsUtils.setCharPref_CW("DefaultColsList", JSON.stringify(columnStates));
 		return;
 	},
 
-    addCWResetMenu_OnClick:function(event){
-		//dump(">>>>>>>>>>>>> miczColumnsWizard: [addCWSaveDefaultMenu_OnClick] test "+event.target.parentNode.getEventHandler('oncommand')+"\r\n");
-		let strBundleCW = Components.classes["@mozilla.org/intl/stringbundle;1"].getService(Components.interfaces.nsIStringBundleService);
+	addCWResetMenu_OnClick: function (event) {
+		// dump(">>>>>>>>>>>>> miczColumnsWizard: [addCWSaveDefaultMenu_OnClick] test "+event.target.parentNode.getEventHandler('oncommand')+"\r\n");
+		let strBundleCW = Cc["@mozilla.org/intl/stringbundle;1"].getService(Cc.nsIStringBundleService);
 		let _bundleCW = strBundleCW.createBundle("chrome://columnswizard/locale/overlay.properties");
-		let promptService = Components.classes["@mozilla.org/embedcomp/prompt-service;1"].getService(Components.interfaces.nsIPromptService);
-		let title_msg=_bundleCW.GetStringFromName("ColumnsWizardNFCols.resetMenu");
-		let text_msg=_bundleCW.GetStringFromName("ColumnsWizard.resetDefault_OnClick_text");
-		if(!promptService.confirm(null,title_msg,text_msg))return;
+		let promptService = Cc["@mozilla.org/embedcomp/prompt-service;1"].getService(Cc.nsIPromptService);
+		let title_msg = _bundleCW.GetStringFromName("ColumnsWizardNFCols.resetMenu");
+		let text_msg = _bundleCW.GetStringFromName("ColumnsWizard.resetDefault_OnClick_text");
+		if (!promptService.confirm(null, title_msg, text_msg)) return;
 		let columnStates = miczColumnsWizardPref_DefaultColsGrid.loadDefaultColRows_Pref();
 		gFolderDisplay.setColumnStates(columnStates, true);
 		return;
 	},
 
-    watchFolders: function(){
-		let mailSessionService = Components.classes["@mozilla.org/messenger/services/session;1"].getService(Components.interfaces.nsIMsgMailSession);
-        mailSessionService.AddFolderListener(miczColumnsWizard.FolderListener, Components.interfaces.nsIFolderListener.added);
-        // The following are already handled internally
-        //mailSessionService.AddFolderListener(FolderListener, Ci.nsIFolderListener.removed);
-        //mailSessionService.AddFolderListener(FolderListener, Ci.nsIFolderListener.event);
-        //dump(">>>>>>>>>>>>> miczColumnsWizard: [watchFolders] \r\n");
-    },
+	watchFolders: function () {
+		let mailSessionService = Cc["@mozilla.org/messenger/services/session;1"].getService(Cc.nsIMsgMailSession);
+		mailSessionService.AddFolderListener(miczColumnsWizard.FolderListener, Cc.nsIFolderListener.added);
+		// The following are already handled internally
+		// mailSessionService.AddFolderListener(FolderListener, Ci.nsIFolderListener.removed);
+		// mailSessionService.AddFolderListener(FolderListener, Ci.nsIFolderListener.event);
+		// dump(">>>>>>>>>>>>> miczColumnsWizard: [watchFolders] \r\n");
+	},
 
-    unwatchFolders: function(){
-		let mailSessionService = Components.classes["@mozilla.org/messenger/services/session;1"].getService(Components.interfaces.nsIMsgMailSession);
-        mailSessionService.RemoveFolderListener(miczColumnsWizard.FolderListener);
-    },
+	unwatchFolders: function () {
+		let mailSessionService = Cc["@mozilla.org/messenger/services/session;1"].getService(Cc.nsIMsgMailSession);
+		mailSessionService.RemoveFolderListener(miczColumnsWizard.FolderListener);
+	},
 
-    initHeadersEditingMenu:function(){
-		if(miczColumnsWizardPrefsUtils.headersEditingActive){
-			miczColumnsWizard.CustColPref=miczColumnsWizard_CustCols.loadCustCols();
-			miczColumnsWizard_CustomColsModUtils.addContextMenu(document,document.getElementById("cw_edit_main_menu_popup"),document.getElementById("cw_edit_context_menu_popup"),document.getElementById("cw_edit_newmain_menu_popup"),miczColumnsWizard.CustColPref,miczColumnsWizardPrefsUtils.stringCustColIndexMod,miczColumnsWizard.editHeaderMenu_OnClick,miczColumnsWizard.editHeaderSubMenu_OnClick);
-			document.getElementById("cw_edit_main_menu").setAttribute("hidden",false);
-			document.getElementById("cw_edit_context_menu").setAttribute("hidden",false);
-			document.getElementById("cw_edit_newmain_menu").setAttribute("hidden",false);
-			//miczLogger.log(">>>>>>>>>>>>> miczColumnsWizard [initHeadersEditingMenu]: Menu UPDATED! \r\n");
-		}else{
-			document.getElementById("cw_edit_main_menu").setAttribute("hidden",true);
-			document.getElementById("cw_edit_context_menu").setAttribute("hidden",true);
-			document.getElementById("cw_edit_newmain_menu").setAttribute("hidden",true);
-			//miczLogger.log(">>>>>>>>>>>>> miczColumnsWizard [initHeadersEditingMenu]: Menu HIDDEN! \r\n");
+	initHeadersEditingMenu: function () {
+		if (miczColumnsWizardPrefsUtils.headersEditingActive) {
+			miczColumnsWizard.CustColPref = miczColumnsWizard_CustCols.loadCustCols();
+			miczColumnsWizard_CustomColsModUtils.addContextMenu(document, document.getElementById("cw_edit_main_menu_popup"), document.getElementById("cw_edit_context_menu_popup"), document.getElementById("cw_edit_newmain_menu_popup"), miczColumnsWizard.CustColPref, miczColumnsWizardPrefsUtils.stringCustColIndexMod, miczColumnsWizard.editHeaderMenu_OnClick, miczColumnsWizard.editHeaderSubMenu_OnClick);
+			document.getElementById("cw_edit_main_menu").setAttribute("hidden", false);
+			document.getElementById("cw_edit_context_menu").setAttribute("hidden", false);
+			document.getElementById("cw_edit_newmain_menu").setAttribute("hidden", false);
+			// miczLogger.log(">>>>>>>>>>>>> miczColumnsWizard [initHeadersEditingMenu]: Menu UPDATED! \r\n");
+		} else {
+			document.getElementById("cw_edit_main_menu").setAttribute("hidden", true);
+			document.getElementById("cw_edit_context_menu").setAttribute("hidden", true);
+			document.getElementById("cw_edit_newmain_menu").setAttribute("hidden", true);
+			// miczLogger.log(">>>>>>>>>>>>> miczColumnsWizard [initHeadersEditingMenu]: Menu HIDDEN! \r\n");
 		}
 	},
-	
-	checkHeadersEditingMenuList:function(element){
-		let current_header=element.parentElement.getAttribute("mail_header");
-		let current_header_value=gFolderDisplay.selectedMessage.getStringProperty(current_header);
-		//miczLogger.log(">>>>>>>>>>>>> miczColumnsWizard [checkHeadersEditingMenuList] current_header=current_header_value: "+current_header+"="+current_header_value+" \r\n");
-		for(let sub_el of Array.from(element.children)){
-			if(current_header_value==sub_el.getAttribute("label")){
-				sub_el.setAttribute('checked',true);
-				//miczLogger.log(">>>>>>>>>>>>> miczColumnsWizard [checkHeadersEditingMenuList] sub_el: "+sub_el.getAttribute("label")+" FOUND!!! \r\n");
-			}else{
-				sub_el.setAttribute('checked',false);
-				//miczLogger.log(">>>>>>>>>>>>> miczColumnsWizard [checkHeadersEditingMenuList] sub_el: "+sub_el.getAttribute("label")+" \r\n");
+
+	checkHeadersEditingMenuList: function (element) {
+		let current_header = element.parentElement.getAttribute("mail_header");
+		let current_header_value = gFolderDisplay.selectedMessage.getStringProperty(current_header);
+		// miczLogger.log(">>>>>>>>>>>>> miczColumnsWizard [checkHeadersEditingMenuList] current_header=current_header_value: "+current_header+"="+current_header_value+" \r\n");
+		for (let sub_el of Array.from(element.children)) {
+			if (current_header_value === sub_el.getAttribute("label")) {
+				sub_el.setAttribute('checked', true);
+				// miczLogger.log(">>>>>>>>>>>>> miczColumnsWizard [checkHeadersEditingMenuList] sub_el: "+sub_el.getAttribute("label")+" FOUND!!! \r\n");
+			} else {
+				sub_el.setAttribute('checked', false);
+				// miczLogger.log(">>>>>>>>>>>>> miczColumnsWizard [checkHeadersEditingMenuList] sub_el: "+sub_el.getAttribute("label")+" \r\n");
 			}
 		}
 	},
 
-	editHeaderMenu_OnClick:function(event){
-		//miczLogger.log(">>>>>>>>>>>>> miczColumnsWizard: [editHeaderMenu_OnClick] colidx: "+JSON.stringify(event.target.getAttribute("colidx"))+"\r\n");
-		let colidx=event.target.getAttribute("colidx")
-		let mail_header=event.target.getAttribute("mail_header");
-		let edit_type=event.target.getAttribute("edit_type");
-		//Get the actual value from message
+	editHeaderMenu_OnClick: function (event) {
+		// miczLogger.log(">>>>>>>>>>>>> miczColumnsWizard: [editHeaderMenu_OnClick] colidx: "+JSON.stringify(event.target.getAttribute("colidx"))+"\r\n");
+		let colidx = event.target.getAttribute("colidx");
+		let mail_header = event.target.getAttribute("mail_header");
+		let edit_type = event.target.getAttribute("edit_type");
+		// Get the actual value from message
 		let msgURI = gFolderDisplay.selectedMessageUris[0];
-		miczColumnsWizard_MsgUtils.init(messenger,msgURI,gDBView,msgWindow,window);
+		miczColumnsWizard_MsgUtils.init(messenger, msgURI, gDBView, msgWindow, window);
 		miczColumnsWizard_MsgUtils.setCurrentHeader(mail_header);
-		let header_value=miczColumnsWizard_MsgUtils.getMsgHeaderValue(mail_header);
-		//Open value editor
-		let args = {"action":"change","value":header_value,"edit_type":edit_type};
+		let header_value = miczColumnsWizard_MsgUtils.getMsgHeaderValue(mail_header);
+		// Open value editor
+		let args = { "action": "change", "value": header_value, "edit_type": edit_type };
 		window.openDialog("chrome://columnswizard/content/mzcw-mailheader-editor.xul", "MailHeaderEditor", "chrome,modal,titlebar,resizable,centerscreen", args);
-		if("save" in args && args.save){
-			let output_value='';
-			if("value" in args && args.value){
-				output_value=args.value;
+		if ("save" in args && args.save) {
+			let output_value = '';
+			if ("value" in args && args.value) {
+				output_value = args.value;
 			}
-			//Save the message with the new value
-			miczColumnsWizard_MsgUtils.saveMsg(output_value,msgURI,miczColumnsWizard_MsgUtils.listener);
+			// Save the message with the new value
+			miczColumnsWizard_MsgUtils.saveMsg(output_value, msgURI, miczColumnsWizard_MsgUtils.listener);
 		}
 	},
 
-	editHeaderSubMenu_OnClick:function(event){	//Here editType is always Fixed List
-		//miczLogger.log(">>>>>>>>>>>>> miczColumnsWizard: [editHeaderSubMenu_OnClick] colidx: "+JSON.stringify(event.target.getAttribute("colidx")));
-		let colidx=event.target.getAttribute("colidx")
-		let mail_header=event.target.getAttribute("mail_header");
-		let header_value=event.target.getAttribute("label");
-		let current_header_value=gFolderDisplay.selectedMessage.getStringProperty(mail_header);
-		if(header_value==current_header_value){
-			header_value='';
+	editHeaderSubMenu_OnClick: function (event) {	// Here editType is always Fixed List
+		// miczLogger.log(">>>>>>>>>>>>> miczColumnsWizard: [editHeaderSubMenu_OnClick] colidx: "+JSON.stringify(event.target.getAttribute("colidx")));
+		let colidx = event.target.getAttribute("colidx");
+		let mail_header = event.target.getAttribute("mail_header");
+		let header_value = event.target.getAttribute("label");
+		let current_header_value = gFolderDisplay.selectedMessage.getStringProperty(mail_header);
+		if (header_value === current_header_value) {
+			header_value = '';
 		}
 		let msgURI = gFolderDisplay.selectedMessageUris[0];
-		//miczLogger.log(">>>>>>>>>>>>> miczColumnsWizard: [editHeaderSubMenu_OnClick] msgURI SELECTED");
-		miczColumnsWizard_MsgUtils.init(messenger,msgURI,gDBView,msgWindow,window);
-		//miczLogger.log(">>>>>>>>>>>>> miczColumnsWizard: [editHeaderSubMenu_OnClick] miczColumnsWizard_MsgUtils.init DONE");
+		// miczLogger.log(">>>>>>>>>>>>> miczColumnsWizard: [editHeaderSubMenu_OnClick] msgURI SELECTED");
+		miczColumnsWizard_MsgUtils.init(messenger, msgURI, gDBView, msgWindow, window);
+		// miczLogger.log(">>>>>>>>>>>>> miczColumnsWizard: [editHeaderSubMenu_OnClick] miczColumnsWizard_MsgUtils.init DONE");
 		miczColumnsWizard_MsgUtils.setCurrentHeader(mail_header);
-		//miczLogger.log(">>>>>>>>>>>>> miczColumnsWizard: [editHeaderSubMenu_OnClick] mail_header SET");
-		//Save the message with the new value
-		//miczLogger.log(">>>>>>>>>>>>> miczColumnsWizard: [editHeaderSubMenu_OnClick] miczColumnsWizard_MsgUtils.saveMsg CALLING");
-		miczColumnsWizard_MsgUtils.saveMsg(header_value,msgURI,miczColumnsWizard_MsgUtils.listener);
-		//miczLogger.log(">>>>>>>>>>>>> miczColumnsWizard: [editHeaderSubMenu_OnClick] miczColumnsWizard_MsgUtils.saveMsg DONE");
+		// miczLogger.log(">>>>>>>>>>>>> miczColumnsWizard: [editHeaderSubMenu_OnClick] mail_header SET");
+		// Save the message with the new value
+		// miczLogger.log(">>>>>>>>>>>>> miczColumnsWizard: [editHeaderSubMenu_OnClick] miczColumnsWizard_MsgUtils.saveMsg CALLING");
+		miczColumnsWizard_MsgUtils.saveMsg(header_value, msgURI, miczColumnsWizard_MsgUtils.listener);
+		// miczLogger.log(">>>>>>>>>>>>> miczColumnsWizard: [editHeaderSubMenu_OnClick] miczColumnsWizard_MsgUtils.saveMsg DONE");
 	},
 
-	updateHeaderEditingMenuObserver:function(ObserverService){
+	updateHeaderEditingMenuObserver: function (ObserverService) {
 		let headerEditingMenuObserver = {
-			observe: function(aSubject,aTopic,aData){
-    			//update header editing menu
-    			miczColumnsWizard.initHeadersEditingMenu();
-    			//dump(">>>>>>>>>>>>> miczColumnsWizard: CW-updateHeaderEditingMenu Observer notified! \r\n");
-  			}
+			observe: function (aSubject, aTopic, aData) {
+				// update header editing menu
+				miczColumnsWizard.initHeadersEditingMenu();
+				// dump(">>>>>>>>>>>>> miczColumnsWizard: CW-updateHeaderEditingMenu Observer notified! \r\n");
+			},
+		};
+		ObserverService.addObserver(headerEditingMenuObserver, "CW-updateHeaderEditingMenu", false);
+	},
+
+	toolbarButtonCommand: function () {
+		let features = (miczColumnsWizardUtils.HostSystem === 'linux') ?
+			'chrome,titlebar,centerscreen,resizable,dependent,instantApply' :
+			'chrome,titlebar,centerscreen,resizable,alwaysRaised,instantApply';
+		window.openDialog('chrome://columnswizard/content/mzcw-settings.xul', 'ColumnsWizard_Settings', features).focus();
+
+	},
+
+	addToolbarButton: function () {
+		let toolbar = document.getElementById("mail-bar3");
+		let buttonId = "mzcw-button";
+		let before_el = document.getElementById("gloda-search").previousSibling;
+		if (before_el === null) {
+			before_el = document.getElementById("button-appmenu").previousSibling;
 		}
-		ObserverService.addObserver(headerEditingMenuObserver,"CW-updateHeaderEditingMenu",false);
-	},
 
-	toolbarButtonCommand:function(){
-		let features = (miczColumnsWizardUtils.HostSystem == 'linux') ?
-          'chrome,titlebar,centerscreen,resizable,dependent,instantApply' :
-          'chrome,titlebar,centerscreen,resizable,alwaysRaised,instantApply';
-		window.openDialog('chrome://columnswizard/content/mzcw-settings.xul','ColumnsWizard_Settings',features).focus();
-
-	},
-
-	addToolbarButton:function(){
-			let toolbar = document.getElementById("mail-bar3");
-			let buttonId = "mzcw-button";
-			let before_el = document.getElementById("gloda-search").previousSibling;
-			if(before_el==null){
-				before_el = document.getElementById("button-appmenu").previousSibling;
+		if (!document.getElementById(buttonId)) {
+			if (toolbar !== null) {
+				toolbar.insertItem(buttonId, before_el);
+				toolbar.setAttribute("currentset", toolbar.currentSet);
+				document.persist(toolbar.id, "currentset");
 			}
-
-			if(!document.getElementById(buttonId)){
-				if(toolbar!=null){
-					toolbar.insertItem(buttonId,before_el);
-					toolbar.setAttribute("currentset", toolbar.currentSet);
-					document.persist(toolbar.id, "currentset");
-				}
-			}
+		}
 	},
 
 };

--- a/src/chrome/content/mzcw-overlay.js
+++ b/src/chrome/content/mzcw-overlay.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 ChromeUtils.import("chrome://columnswizard/content/mzcw-prefsutils.jsm");
 ChromeUtils.import("chrome://columnswizard/content/mzcw-customcolsmodutils.jsm");
 ChromeUtils.import("chrome://columnswizard/content/mzcw-msgutils.jsm");
@@ -26,7 +27,7 @@ var miczColumnsWizard = {
 			miczColumnsWizard.addToolbarButton();
 		}
 
-		let ObserverService = Cc["@mozilla.org/observer-service;1"].getService(Cc.nsIObserverService);
+		let ObserverService = Cc["@mozilla.org/observer-service;1"].getService(Ci.nsIObserverService);
 
 		miczColumnsWizard.addNewCustColObserver(ObserverService);
 		miczColumnsWizard.deleteCustColObserver(ObserverService);
@@ -86,7 +87,7 @@ var miczColumnsWizard = {
 		let CustColObserver = {
 			observe: function (aSubject, aTopic, aData) {
 				// dump(">>>>>>>>>>>>> miczColumnsWizard->CustColObserver: [aSubject] "+aData+"\r\n");
-				let ObserverService = Cc["@mozilla.org/observer-service;1"].getService(Cc.nsIObserverService);
+				let ObserverService = Cc["@mozilla.org/observer-service;1"].getService(Ci.nsIObserverService);
 				miczColumnsWizard_CustCols.removeCustomColumn(aData, ObserverService);
 				miczColumnsWizard_CustCols.deleteCustCol(aData);
 			},
@@ -98,7 +99,7 @@ var miczColumnsWizard = {
 		let CustColObserver = {
 			observe: function (aSubject, aTopic, aData) {
 				// dump(">>>>>>>>>>>>> miczColumnsWizard->CustColObserver: [aSubject] "+aData+"\r\n");
-				let ObserverService = Cc["@mozilla.org/observer-service;1"].getService(Cc.nsIObserverService);
+				let ObserverService = Cc["@mozilla.org/observer-service;1"].getService(Ci.nsIObserverService);
 				// update cust col info in the message list
 				miczColumnsWizard_CustCols.updateCustomColumn(JSON.parse(aData));
 			},
@@ -167,7 +168,7 @@ var miczColumnsWizard = {
 
 	activateCustomDBHeader: function (newHeader) {
 		// dump(">>>>>>>>>>>>> miczColumnsWizard: [customDBHeaders] "+newHeader+"\r\n");
-		// let prefService = Cc["@mozilla.org/preferences-service;1"].getService(Cc.nsIPrefBranch);
+		// let prefService = Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefBranch);
 		// let currentHeaders = prefService.getCharPref("mailnews.customDBHeaders");
 		let currentHeaders = miczColumnsWizardPrefsUtils.getCharPref("mailnews.customDBHeaders");
 		let re = new RegExp("(^| )" + newHeader + "( |$)", "i");
@@ -180,7 +181,7 @@ var miczColumnsWizard = {
 
 	deactivateCustomDBHeader: function (newHeader) {
 		// dump(">>>>>>>>>>>>> miczColumnsWizard: [deactivate customDBHeaders] "+newHeader+"\r\n");
-		// let prefService = Cc["@mozilla.org/preferences-service;1"].getService(Cc.nsIPrefBranch);
+		// let prefService = Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefBranch);
 		// let currentHeaders = prefService.getCharPref("mailnews.customDBHeaders");
 		let currentHeaders = miczColumnsWizardPrefsUtils.getCharPref("mailnews.customDBHeaders");
 		let re = new RegExp("(^| )" + newHeader + "( |$)", "i");
@@ -190,7 +191,7 @@ var miczColumnsWizard = {
 	},
 
 	showColumns: function (tab) {
-		// let prefs = Cc["@mozilla.org/preferences-service;1"].getService(Cc.nsIPrefService);
+		// let prefs = Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefService);
 		// prefs = prefs.getBranch("extensions.ColumnsWizard.");
 		this.showLocation = miczColumnsWizardPrefsUtils.getBoolPref_CW("ShowLocation");
 		this.showAccount = miczColumnsWizardPrefsUtils.getBoolPref_CW("ShowAccount");
@@ -239,13 +240,12 @@ var miczColumnsWizard = {
 						aPopup.removeChild(aPopup.childNodes[2]);
 					}
 					// check if we're using the colcw default for new folders
-					// let prefsc = Cc["@mozilla.org/preferences-service;1"].getService(Cc.nsIPrefService);
+					// let prefsc = Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefService);
 					// let prefs = prefsc.getBranch("extensions.ColumnsWizard.DefaultColsList.");
 					// let cw_active=prefs.getBoolPref("active");
 					let cw_active = miczColumnsWizardPrefsUtils.defaultColsListActive;
 
-					let strBundleCW = Cc["@mozilla.org/intl/stringbundle;1"].getService(Cc.nsIStringBundleService);
-					let _bundleCW = strBundleCW.createBundle("chrome://columnswizard/locale/overlay.properties");
+					let _bundleCW = Services.strings.createBundle("chrome://columnswizard/locale/overlay.properties");
 
 					aPopup.childNodes[1].setAttribute('hidden', cw_active ? 'true' : 'false');
 
@@ -280,14 +280,13 @@ var miczColumnsWizard = {
 
 	addCWSaveDefaultMenu_OnClick: function (event) {
 		// dump(">>>>>>>>>>>>> miczColumnsWizard: [addCWResetMenu_OnClick] test "+event.target.parentNode.getEventHandler('oncommand')+"\r\n");
-		let strBundleCW = Cc["@mozilla.org/intl/stringbundle;1"].getService(Cc.nsIStringBundleService);
-		let _bundleCW = strBundleCW.createBundle("chrome://columnswizard/locale/overlay.properties");
-		let promptService = Cc["@mozilla.org/embedcomp/prompt-service;1"].getService(Cc.nsIPromptService);
+		let _bundleCW = Services.strings.createBundle("chrome://columnswizard/locale/overlay.properties");
+		let promptService = Cc["@mozilla.org/embedcomp/prompt-service;1"].getService(Ci.nsIPromptService);
 		let title_msg = _bundleCW.GetStringFromName("ColumnsWizardNFCols.saveDefault");
 		let text_msg = _bundleCW.GetStringFromName("ColumnsWizard.saveDefault_OnClick_text");
 		if (!promptService.confirm(null, title_msg, text_msg)) return;
 		let columnStates = gFolderDisplay.getColumnStates();
-		// let prefsc = Cc["@mozilla.org/preferences-service;1"].getService(Cc.nsIPrefService);
+		// let prefsc = Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefService);
 		// let prefs = prefsc.getBranch("extensions.ColumnsWizard.");
 		// prefs.setCharPref("DefaultColsList",JSON.stringify(columnStates));
 		miczColumnsWizardPrefsUtils.setCharPref_CW("DefaultColsList", JSON.stringify(columnStates));
@@ -296,9 +295,8 @@ var miczColumnsWizard = {
 
 	addCWResetMenu_OnClick: function (event) {
 		// dump(">>>>>>>>>>>>> miczColumnsWizard: [addCWSaveDefaultMenu_OnClick] test "+event.target.parentNode.getEventHandler('oncommand')+"\r\n");
-		let strBundleCW = Cc["@mozilla.org/intl/stringbundle;1"].getService(Cc.nsIStringBundleService);
-		let _bundleCW = strBundleCW.createBundle("chrome://columnswizard/locale/overlay.properties");
-		let promptService = Cc["@mozilla.org/embedcomp/prompt-service;1"].getService(Cc.nsIPromptService);
+		let _bundleCW = Services.strings.createBundle("chrome://columnswizard/locale/overlay.properties");
+		let promptService = Cc["@mozilla.org/embedcomp/prompt-service;1"].getService(Ci.nsIPromptService);
 		let title_msg = _bundleCW.GetStringFromName("ColumnsWizardNFCols.resetMenu");
 		let text_msg = _bundleCW.GetStringFromName("ColumnsWizard.resetDefault_OnClick_text");
 		if (!promptService.confirm(null, title_msg, text_msg)) return;
@@ -308,8 +306,8 @@ var miczColumnsWizard = {
 	},
 
 	watchFolders: function () {
-		let mailSessionService = Cc["@mozilla.org/messenger/services/session;1"].getService(Cc.nsIMsgMailSession);
-		mailSessionService.AddFolderListener(miczColumnsWizard.FolderListener, Cc.nsIFolderListener.added);
+		let mailSessionService = Cc["@mozilla.org/messenger/services/session;1"].getService(Ci.nsIMsgMailSession);
+		mailSessionService.AddFolderListener(miczColumnsWizard.FolderListener, Ci.nsIFolderListener.added);
 		// The following are already handled internally
 		// mailSessionService.AddFolderListener(FolderListener, Ci.nsIFolderListener.removed);
 		// mailSessionService.AddFolderListener(FolderListener, Ci.nsIFolderListener.event);
@@ -317,7 +315,7 @@ var miczColumnsWizard = {
 	},
 
 	unwatchFolders: function () {
-		let mailSessionService = Cc["@mozilla.org/messenger/services/session;1"].getService(Cc.nsIMsgMailSession);
+		let mailSessionService = Cc["@mozilla.org/messenger/services/session;1"].getService(Ci.nsIMsgMailSession);
 		mailSessionService.RemoveFolderListener(miczColumnsWizard.FolderListener);
 	},
 

--- a/src/chrome/content/mzcw-prefobserver.js
+++ b/src/chrome/content/mzcw-prefobserver.js
@@ -1,4 +1,5 @@
 "use strict";
+
 /**
  * @constructor
  *
@@ -7,69 +8,68 @@
  *   branch, pref_leaf_name
  */
 miczColumnsWizard.PrefListener = function (branch_name, callback) {
-  // Keeping a reference to the observed preference branch or it will get
-  // garbage collected.
-  var prefService = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
-  this._branch = prefService.getBranch(branch_name);
-  this._branch.QueryInterface(Components.interfaces.nsIPrefBranch);
-  this._callback = callback;
-}
+	// Keeping a reference to the observed preference branch or it will get
+	// garbage collected.
+	var prefService = Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefService);
+	this._branch = prefService.getBranch(branch_name);
+	this._branch.QueryInterface(Ci.nsIPrefBranch);
+	this._callback = callback;
+};
 
-miczColumnsWizard.PrefListener.prototype.observe = function(subject, topic, data) {
-  if (topic == 'nsPref:changed')
-    this._callback(this._branch, data);
+miczColumnsWizard.PrefListener.prototype.observe = function (subject, topic, data) {
+	if (topic === 'nsPref:changed')
+		this._callback(this._branch, data);
 };
 
 /**
  * @param {boolean=} trigger if true triggers the registered function
  *   on registration, that is, when this method is called.
  */
-miczColumnsWizard.PrefListener.prototype.register = function(trigger) {
-  this._branch.addObserver('', this, false);
-  if (trigger) {
-    let that = this;
-    this._branch.getChildList('', {}).
-      forEach(function (pref_leaf_name)
-        { that._callback(that._branch, pref_leaf_name); });
-  }
+miczColumnsWizard.PrefListener.prototype.register = function (trigger) {
+	this._branch.addObserver('', this, false);
+	if (trigger) {
+		let that = this;
+		this._branch.getChildList('', {}).
+			forEach(function (pref_leaf_name) { that._callback(that._branch, pref_leaf_name); });
+	}
 };
 
-miczColumnsWizard.PrefListener.prototype.unregister = function() {
-  if (this._branch)
-    this._branch.removeObserver('', this);
+miczColumnsWizard.PrefListener.prototype.unregister = function () {
+	if (this._branch)
+		this._branch.removeObserver('', this);
 };
 
-//Adding preferences listener
+// Adding preferences listener
 miczColumnsWizard.CWListener = new miczColumnsWizard.PrefListener(
-  "extensions.ColumnsWizard.CustCols.def.",
-  function(branch, name) {//dump("PrefListener call: "+name+"\n\r");
-    var ObserverService = Components.classes["@mozilla.org/observer-service;1"].getService(Components.interfaces.nsIObserverService);
-    //-- comment deprecated -- with the pref name AddCOLNAME, get the COLNAME all lowercase!!
-    let cwColName=name;//.substr(3).toLowerCase();
-    let cwCustColPref=miczColumnsWizard_CustCols.loadCustCols();
-    //dump(">>>>>>>>>>>>> miczColumnsWizard.PrefListener: [PrefName|cwColName] "+name+"|"+cwColName+"\r\n");
-    if(cwCustColPref[cwColName].enabled){
-      //checbox checked
-      miczColumnsWizard_CustCols.addCustomColumn(cwCustColPref[cwColName],ObserverService);
-      if(cwCustColPref[cwColName].isCustom!=false){
-        miczColumnsWizard.activateCustomDBHeader(cwCustColPref[cwColName].dbHeader);
-      }
-    }else{
-      //checbox not checked
-      miczColumnsWizard.removeCustomColumn(cwColName,ObserverService);
-      //Don't do this, the customDBHeader could have been set by another extension
-      /*if(cwCustColPref[cwColName].iscustom!=false){
-        miczColumnsWizard.deactivateCustomDBHeader(cwCustColPref[cwColName].DBHeader);
-      }*/
-    }
-  }
+	"extensions.ColumnsWizard.CustCols.def.",
+	function (branch, name) { // dump("PrefListener call: "+name+"\n\r");
+		var ObserverService = Cc["@mozilla.org/observer-service;1"].getService(Ci.nsIObserverService);
+		// -- comment deprecated -- with the pref name AddCOLNAME, get the COLNAME all lowercase!!
+		let cwColName = name;// .substr(3).toLowerCase();
+		let cwCustColPref = miczColumnsWizard_CustCols.loadCustCols();
+		// dump(">>>>>>>>>>>>> miczColumnsWizard.PrefListener: [PrefName|cwColName] "+name+"|"+cwColName+"\r\n");
+		if (cwCustColPref[cwColName].enabled) {
+			// checbox checked
+			miczColumnsWizard_CustCols.addCustomColumn(cwCustColPref[cwColName], ObserverService);
+			if (cwCustColPref[cwColName].isCustom !== false) {
+				miczColumnsWizard.activateCustomDBHeader(cwCustColPref[cwColName].dbHeader);
+			}
+		} else {
+			// checbox not checked
+			miczColumnsWizard.removeCustomColumn(cwColName, ObserverService);
+			// Don't do this, the customDBHeader could have been set by another extension
+			/* if(cwCustColPref[cwColName].iscustom!=false){
+			  miczColumnsWizard.deactivateCustomDBHeader(cwCustColPref[cwColName].DBHeader);
+			}*/
+		}
+	}
 );
 miczColumnsWizard.CWListener.register(false);
 
 miczColumnsWizard.CWListenerModActive = new miczColumnsWizard.PrefListener(
-  "extensions.ColumnsWizard.CustCols.mod_active",
-  function(branch, name){
-  	miczColumnsWizard.initHeadersEditingMenu();
-  }
+	"extensions.ColumnsWizard.CustCols.mod_active",
+	function (branch, name) {
+		miczColumnsWizard.initHeadersEditingMenu();
+	}
 );
 miczColumnsWizard.CWListenerModActive.register(false);

--- a/src/chrome/content/mzcw-prefsutils.jsm
+++ b/src/chrome/content/mzcw-prefsutils.jsm
@@ -3,21 +3,22 @@
  *
  * */
 "use strict";
-ChromeUtils.import("resource://gre/modules/Services.jsm");
+
+const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 
 let EXPORTED_SYMBOLS = ["miczColumnsWizardPrefsUtils"];
 
 var miczColumnsWizardPrefsUtils = {
 	service: Services.prefs,
-	pref_base:'extensions.ColumnsWizard.',
+	pref_base: 'extensions.ColumnsWizard.',
 	pref_custcols: "extensions.ColumnsWizard.CustCols.",
-    pref_custcols_def: "extensions.ColumnsWizard.CustCols.def.",
-    pref_defcolslist: "extensions.ColumnsWizard.DefaultColsList.",
+	pref_custcols_def: "extensions.ColumnsWizard.CustCols.def.",
+	pref_defcolslist: "extensions.ColumnsWizard.DefaultColsList.",
 
-    get isDebug() {
-    	return this.getBoolPref_CW("debug");
-    },
-    
+	get isDebug() {
+		return this.getBoolPref_CW("debug");
+	},
+
 	get headersEditingActive() {
 		return this.getBoolPref_CW("CustCols.mod_active");
 	},
@@ -34,107 +35,103 @@ var miczColumnsWizardPrefsUtils = {
 		return this.getBoolPref_CW("MailHeader.put_original_in_trash");
 	},
 
-	get defaultColsListActive(){
-		return this.getBoolPref(this.pref_defcolslist+'active');
+	get defaultColsListActive() {
+		return this.getBoolPref(this.pref_defcolslist + 'active');
 	},
 
 	get firstRun() {
 		return this.getBoolPref_CW("firstRun");
 	},
 
-	firstRunDone:function(){
-		this.setBoolPref_CW('firstRun',false);
+	firstRunDone: function () {
+		this.setBoolPref_CW('firstRun', false);
 	},
 
-	getCustColsIndex:function(){
-		return this.getCharPref(this.pref_custcols+'index');
+	getCustColsIndex: function () {
+		return this.getCharPref(this.pref_custcols + 'index');
 	},
 
-	setCustColsIndex:function(index){
-		this.setCharPref(this.pref_custcols+'index',index);
+	setCustColsIndex: function (index) {
+		this.setCharPref(this.pref_custcols + 'index', index);
 	},
 
-	getCustColsActive:function(){
-		return this.getBoolPref(this.pref_custcols+'active');
+	getCustColsActive: function () {
+		return this.getBoolPref(this.pref_custcols + 'active');
 	},
 
-	setCustColsActive:function(active){
-		this.setBoolPref(this.pref_custcols+'active',active);
+	setCustColsActive: function (active) {
+		this.setBoolPref(this.pref_custcols + 'active', active);
 	},
 
-	getCustColsIndexMod:function(){
-		return this.getCharPref(this.pref_custcols+'index_mod');
+	getCustColsIndexMod: function () {
+		return this.getCharPref(this.pref_custcols + 'index_mod');
 	},
 
-	setCustColsIndexMod:function(index){
-		this.setCharPref(this.pref_custcols+'index_mod',index);
+	setCustColsIndexMod: function (index) {
+		this.setCharPref(this.pref_custcols + 'index_mod', index);
 	},
 
-	getCustColsModActive:function(){
-		return this.getBoolPref(this.pref_custcols+'mod_active');
+	getCustColsModActive: function () {
+		return this.getBoolPref(this.pref_custcols + 'mod_active');
 	},
 
-	setCustColsModActive:function(mod_active){
-		this.setBoolPref(this.pref_custcols+'mod_active',mod_active);
+	setCustColsModActive: function (mod_active) {
+		this.setBoolPref(this.pref_custcols + 'mod_active', mod_active);
 	},
 
-	getCustColDef:function(custcol){
-		return this.getCharPref(this.pref_custcols_def+custcol);
+	getCustColDef: function (custcol) {
+		return this.getCharPref(this.pref_custcols_def + custcol);
 	},
 
-	setCustColDef:function(custcol,value){
-		this.setCharPref(this.pref_custcols_def+custcol,value);
+	setCustColDef: function (custcol, value) {
+		this.setCharPref(this.pref_custcols_def + custcol, value);
 	},
 
-	getCustColBool:function(custcol){
-		return this.getBoolPref(this.pref_custcols+custcol);
+	getCustColBool: function (custcol) {
+		return this.getBoolPref(this.pref_custcols + custcol);
 	},
 
-	setCustColBool:function(custcol,value){
-		this.setBoolPref(this.pref_custcols+custcol,value);
+	setCustColBool: function (custcol, value) {
+		this.setBoolPref(this.pref_custcols + custcol, value);
 	},
 
 	existsCharPref: function existsCharPref(pref) {
 		try {
-			if(this.service.prefHasUserValue(pref))
+			if (this.service.prefHasUserValue(pref))
 				return true;
 			if (this.service.getCharPref(pref))
 				return true;
-		}
-		catch (e) {return false; }
+		} catch (e) { return false; }
 		return false;
 	},
 
 	existsBoolPref: function existsBoolPref(pref) {
 		try {
-			if(this.service.prefHasUserValue(pref))
+			if (this.service.prefHasUserValue(pref))
 				return true;
 			if (this.service.getBoolPref(pref))
 				return true;
-		}
-		catch (e) {return false; }
+		} catch (e) { return false; }
 		return false;
 	},
 
 	getBoolPref_CW: function getBoolPref_CW(p) {
-	  let ans;
-	  try {
-	    ans = this.service.getBoolPref(this.pref_base + p);
-		}
-		catch(ex) {
-		  throw(ex);
+		let ans;
+		try {
+			ans = this.service.getBoolPref(this.pref_base + p);
+		} catch (ex) {
+			throw (ex);
 		}
 		return ans;
 	},
 
 	getBoolPref: function getBoolPref(p) {
-	  let ans;
-	  try {
-	    ans = this.service.getBoolPref(p);
-		}
-		catch(ex) {
-		  //throw(ex);
-		  return false;
+		let ans;
+		try {
+			ans = this.service.getBoolPref(p);
+		} catch (ex) {
+			// throw(ex);
+			return false;
 		}
 		return ans;
 	},
@@ -179,4 +176,4 @@ var miczColumnsWizardPrefsUtils = {
 		return this.service.setIntPref(p, v);
 	},
 
-}
+};

--- a/src/chrome/content/mzcw-settings-customcolseditor.js
+++ b/src/chrome/content/mzcw-settings-customcolseditor.js
@@ -109,7 +109,7 @@ var miczColumnsWizardPref_CustColEditor = {
 						if (CustColIndexStr !== '') {
 							CustColIndex = JSON.parse(CustColIndexStr);
 							// dump(">>>>>>>>>>>>> miczColumnsWizard->onAccept: [newcol.index] "+JSON.stringify(newcol.index)+"\r\n");
-							if (CustColIndex.indexOf(newcol.index) !== -1) {
+							if (CustColIndex.includes(newcol.index)) {
 								// custom column already present
 								// dump(">>>>>>>>>>>>> miczColumnsWizard->onAccept: [CustColIndex] "+JSON.stringify(CustColIndex)+"\r\n");
 								let _bundleCW = Services.strings.createBundle("chrome://columnswizard/locale/mzcw-settings-customcolseditor.properties");
@@ -264,7 +264,7 @@ var miczColumnsWizardPref_CustColEditor = {
 				let destFullPath = OS.Path.join(destPath, newname);
 				// dump(">>>>>>>>>>>>> miczColumnsWizard->saveIcon: [file.path] "+JSON.stringify(file.path)+"\r\n");
 				// dump(">>>>>>>>>>>>> miczColumnsWizard->saveIcon: [destPath] "+JSON.stringify(destPath)+"\r\n");
-				if (file.path.indexOf(destPath) === -1) {	// if the icon is already in the dest folder (we're modifying a cust col), do nothing!
+				if (!file.path.includes(destPath)) {	// if the icon is already in the dest folder (we're modifying a cust col), do nothing!
 					OS.File.copy(file.path, destFullPath);
 				}
 				return destFullPath;

--- a/src/chrome/content/mzcw-settings-customcolseditor.js
+++ b/src/chrome/content/mzcw-settings-customcolseditor.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 ChromeUtils.import("chrome://columnswizard/content/mzcw-customcolsgrid.jsm");
 ChromeUtils.import("chrome://columnswizard/content/mzcw-customcolsmodutils.jsm");
 ChromeUtils.import("chrome://columnswizard/content/mzcw-prefsutils.jsm");
@@ -21,8 +22,7 @@ var miczColumnsWizardPref_CustColEditor = {
 					// break;
 					case "edit":
 						let currcol = JSON.parse(args.currcol);
-						let strBundleCW = Cc["@mozilla.org/intl/stringbundle;1"].getService(Ci.nsIStringBundleService);
-						let _bundleCW = strBundleCW.createBundle("chrome://columnswizard/locale/mzcw-settings-customcolseditor.properties");
+						let _bundleCW = Services.strings.createBundle("chrome://columnswizard/locale/mzcw-settings-customcolseditor.properties");
 						document.getElementById("cw_desc.label").label = _bundleCW.GetStringFromName("ColumnsWizard.DescEdit.label");
 
 						// fill the fields
@@ -112,8 +112,7 @@ var miczColumnsWizardPref_CustColEditor = {
 							if (CustColIndex.indexOf(newcol.index) !== -1) {
 								// custom column already present
 								// dump(">>>>>>>>>>>>> miczColumnsWizard->onAccept: [CustColIndex] "+JSON.stringify(CustColIndex)+"\r\n");
-								let strBundleCW = Cc["@mozilla.org/intl/stringbundle;1"].getService(Ci.nsIStringBundleService);
-								let _bundleCW = strBundleCW.createBundle("chrome://columnswizard/locale/mzcw-settings-customcolseditor.properties");
+								let _bundleCW = Services.strings.createBundle("chrome://columnswizard/locale/mzcw-settings-customcolseditor.properties");
 								let prompts = Cc["@mozilla.org/embedcomp/prompt-service;1"].getService(Ci.nsIPromptService);
 								prompts.alert(window,
 									_bundleCW.GetStringFromName("ColumnsWizard.emptyFields.title"),
@@ -184,8 +183,7 @@ var miczColumnsWizardPref_CustColEditor = {
 		// The fields must be filled!!
 		// The input are already sanitized elsewhere...
 		if ((document.getElementById("ColumnsWizard.id").value === "") || (document.getElementById("ColumnsWizard.dbHeader").value === "") || (document.getElementById("ColumnsWizard.labelString").value === "") || (document.getElementById("ColumnsWizard.tooltipString").value === "")) {
-			let strBundleCW = Cc["@mozilla.org/intl/stringbundle;1"].getService(Ci.nsIStringBundleService);
-			let _bundleCW = strBundleCW.createBundle("chrome://columnswizard/locale/mzcw-settings-customcolseditor.properties");
+			let _bundleCW = Services.strings.createBundle("chrome://columnswizard/locale/mzcw-settings-customcolseditor.properties");
 			let prompts = Cc["@mozilla.org/embedcomp/prompt-service;1"].getService(Ci.nsIPromptService);
 			prompts.alert(window,
 				_bundleCW.GetStringFromName("ColumnsWizard.emptyFields.title"),
@@ -230,8 +228,7 @@ var miczColumnsWizardPref_CustColEditor = {
 	},
 
 	chooseIcon: function () {
-		let strBundleCW = Cc["@mozilla.org/intl/stringbundle;1"].getService(Ci.nsIStringBundleService);
-		let _bundleCW = strBundleCW.createBundle("chrome://columnswizard/locale/mzcw-settings-customcolseditor.properties");
+		let _bundleCW = Services.strings.createBundle("chrome://columnswizard/locale/mzcw-settings-customcolseditor.properties");
 		let fp = Cc["@mozilla.org/filepicker;1"].createInstance(Ci.nsIFilePicker);
 		fp.init(window, _bundleCW.GetStringFromName("ColumnsWizard.chooseIcon.title") + "...", Ci.nsIFilePicker.modeOpen);
 		fp.appendFilters(Ci.nsIFilePicker.filterImages);

--- a/src/chrome/content/mzcw-settings-customcolseditor.js
+++ b/src/chrome/content/mzcw-settings-customcolseditor.js
@@ -1,177 +1,178 @@
 "use strict";
+
 ChromeUtils.import("chrome://columnswizard/content/mzcw-customcolsgrid.jsm");
 ChromeUtils.import("chrome://columnswizard/content/mzcw-customcolsmodutils.jsm");
 ChromeUtils.import("chrome://columnswizard/content/mzcw-prefsutils.jsm");
 ChromeUtils.import("resource://gre/modules/osfile.jsm");
 
-var miczColumnsWizard={};
+var miczColumnsWizard = {};
 var miczColumnsWizardPref_CustColEditor = {
 
-	_sanitize_ID_regex:"([A-Za-z0-9\-\_]+)",
-	_sanitize_dbHeader_regex:"([\x21-\x7E2]+)",
+	_sanitize_ID_regex: "([A-Za-z0-9\-\_]+)",
+	_sanitize_dbHeader_regex: "([\x21-\x7E2]+)",
 
-	onLoad: function(){
-		if ("arguments" in window && window.arguments[0]){
+	onLoad: function () {
+		if ("arguments" in window && window.arguments[0]) {
 			let args = window.arguments[0];
 
-			if ("action" in args){
-				switch (args.action){
-					//case "new": //window.document.getElementById("ColumnsWizard.dbHeader").setAttribute("value","ok");
-					//break;
+			if ("action" in args) {
+				switch (args.action) {
+					// case "new": //window.document.getElementById("ColumnsWizard.dbHeader").setAttribute("value","ok");
+					// break;
 					case "edit":
-						let currcol=JSON.parse(args.currcol);
-						let strBundleCW = Components.classes["@mozilla.org/intl/stringbundle;1"].getService(Components.interfaces.nsIStringBundleService);
+						let currcol = JSON.parse(args.currcol);
+						let strBundleCW = Cc["@mozilla.org/intl/stringbundle;1"].getService(Ci.nsIStringBundleService);
 						let _bundleCW = strBundleCW.createBundle("chrome://columnswizard/locale/mzcw-settings-customcolseditor.properties");
-						document.getElementById("cw_desc.label").label=_bundleCW.GetStringFromName("ColumnsWizard.DescEdit.label");
+						document.getElementById("cw_desc.label").label = _bundleCW.GetStringFromName("ColumnsWizard.DescEdit.label");
 
-						//fill the fields
-						document.getElementById("ColumnsWizard.id").setAttribute("value",currcol.index);
-						document.getElementById("ColumnsWizard.dbHeader").setAttribute("value",currcol.dbHeader);
-						document.getElementById("ColumnsWizard.labelString").setAttribute("value",currcol.labelString);
+						// fill the fields
+						document.getElementById("ColumnsWizard.id").setAttribute("value", currcol.index);
+						document.getElementById("ColumnsWizard.dbHeader").setAttribute("value", currcol.dbHeader);
+						document.getElementById("ColumnsWizard.labelString").setAttribute("value", currcol.labelString);
 
-						if((currcol.labelImagePath)&&(currcol.labelImagePath!="")){
+						if ((currcol.labelImagePath) && (currcol.labelImagePath !== "")) {
 							this.setIconUI(currcol.labelImagePath);
 						}
 
-						document.getElementById("ColumnsWizard.tooltipString").setAttribute("value",currcol.tooltipString);
-						document.getElementById("ColumnsWizard.sortnumber").setAttribute("checked",currcol.sortnumber);
-						document.getElementById("ColumnsWizard.searchable").setAttribute("checked",currcol.isSearchable);
-						document.getElementById("ColumnsWizard.enabled").setAttribute("checked",currcol.enabled);
+						document.getElementById("ColumnsWizard.tooltipString").setAttribute("value", currcol.tooltipString);
+						document.getElementById("ColumnsWizard.sortnumber").setAttribute("checked", currcol.sortnumber);
+						document.getElementById("ColumnsWizard.searchable").setAttribute("checked", currcol.isSearchable);
+						document.getElementById("ColumnsWizard.enabled").setAttribute("checked", currcol.enabled);
 
-						//disable the ID and dbheader field
-						document.getElementById("ColumnsWizard.id").setAttribute("readonly",true);
-						document.getElementById("ColumnsWizard.dbHeader").setAttribute("readonly",true);
+						// disable the ID and dbheader field
+						document.getElementById("ColumnsWizard.id").setAttribute("readonly", true);
+						document.getElementById("ColumnsWizard.dbHeader").setAttribute("readonly", true);
 						document.getElementById("ColumnsWizard.labelString").focus();
 
-						//mod data
-						if(currcol.isEditable!==undefined){
-							document.getElementById("ColumnsWizard.mod").setAttribute("checked",currcol.isEditable);
-							document.getElementById("ColumnsWizard.mod2").setAttribute("checked",currcol.isEditable);
+						// mod data
+						if (currcol.isEditable !== undefined) {
+							document.getElementById("ColumnsWizard.mod").setAttribute("checked", currcol.isEditable);
+							document.getElementById("ColumnsWizard.mod2").setAttribute("checked", currcol.isEditable);
 						}
-						if(currcol.editType!==undefined){
-							document.getElementById("ColumnsWizard.mod_type_freetext").setAttribute("selected",currcol.editType==document.getElementById("ColumnsWizard.mod_type_freetext").value);
-							document.getElementById("ColumnsWizard.mod_type_number").setAttribute("selected",currcol.editType==document.getElementById("ColumnsWizard.mod_type_number").value);
-							document.getElementById("ColumnsWizard.mod_type_fixedlist").setAttribute("selected",currcol.editType==document.getElementById("ColumnsWizard.mod_type_fixedlist").value);
-							document.getElementById("ColumnsWizard.mod_type_group").value=currcol.editType;
-							if(currcol.editType!=document.getElementById("ColumnsWizard.mod_type_fixedlist").value){	//we are doing this because here this.enableHeaderFixedList() is not working!
-								document.getElementById('ColumnsWizard.mod_type_fixedlist.list').disabled=true;
-								document.getElementById('ColumnsWizard.mod_type_fixedlist.list.desc').disabled=true;
-							}else{
-								document.getElementById('ColumnsWizard.mod_type_fixedlist.list').disabled=false;
-								document.getElementById('ColumnsWizard.mod_type_fixedlist.list.desc').disabled=false;
+						if (currcol.editType !== undefined) {
+							document.getElementById("ColumnsWizard.mod_type_freetext").setAttribute("selected", currcol.editType === document.getElementById("ColumnsWizard.mod_type_freetext").value);
+							document.getElementById("ColumnsWizard.mod_type_number").setAttribute("selected", currcol.editType === document.getElementById("ColumnsWizard.mod_type_number").value);
+							document.getElementById("ColumnsWizard.mod_type_fixedlist").setAttribute("selected", currcol.editType === document.getElementById("ColumnsWizard.mod_type_fixedlist").value);
+							document.getElementById("ColumnsWizard.mod_type_group").value = currcol.editType;
+							if (currcol.editType !== document.getElementById("ColumnsWizard.mod_type_fixedlist").value) {	// we are doing this because here this.enableHeaderFixedList() is not working!
+								document.getElementById('ColumnsWizard.mod_type_fixedlist.list').disabled = true;
+								document.getElementById('ColumnsWizard.mod_type_fixedlist.list.desc').disabled = true;
+							} else {
+								document.getElementById('ColumnsWizard.mod_type_fixedlist.list').disabled = false;
+								document.getElementById('ColumnsWizard.mod_type_fixedlist.list.desc').disabled = false;
 							}
 						}
-						if(currcol.editFixedList!==undefined)document.getElementById("ColumnsWizard.mod_type_fixedlist.list").setAttribute("value",(currcol.editFixedList).join("\r\n"));
+						if (currcol.editFixedList !== undefined) document.getElementById("ColumnsWizard.mod_type_fixedlist.list").setAttribute("value", (currcol.editFixedList).join("\r\n"));
 
-						//set the value on the label in the advanced tab
-						document.getElementById('cw_adv_msg_header').setAttribute("value",currcol.dbHeader);
-					break;
+						// set the value on the label in the advanced tab
+						document.getElementById('cw_adv_msg_header').setAttribute("value", currcol.dbHeader);
+						break;
 				}
 			}
 		}
-		//Fixing window height
+		// Fixing window height
 		this.fixWinHeight();
 		this.enableAdvancedTabContent();
 	},
 
-	onAccept:function(){
-		if(!miczColumnsWizardPref_CustColEditor.checkFields()){
+	onAccept: function () {
+		if (!miczColumnsWizardPref_CustColEditor.checkFields()) {
 			return false;
 		}
 
-		if ("arguments" in window && window.arguments[0]){
+		if ("arguments" in window && window.arguments[0]) {
 			let args = window.arguments[0];
-			let newcol={};
+			let newcol = {};
 
-			let re_id=new RegExp(miczColumnsWizardPref_CustColEditor._sanitize_ID_regex,'ig');
-			let re_dbh=new RegExp(miczColumnsWizardPref_CustColEditor._sanitize_dbHeader_regex,'g');
+			let re_id = new RegExp(miczColumnsWizardPref_CustColEditor._sanitize_ID_regex, 'ig');
+			let re_dbh = new RegExp(miczColumnsWizardPref_CustColEditor._sanitize_dbHeader_regex, 'g');
 
-			if ("action" in args){
-				switch (args.action){
-					case "new":  //Save new custom column
-						//fixed val
-						newcol.isBundled=false;
-						newcol.isCustom=true;
-						newcol.def="";
-						//get userinput val
-						if(document.getElementById("ColumnsWizard.id").value.match(re_id)!=null){
-							newcol.index=document.getElementById("ColumnsWizard.id").value.match(re_id).join('').toLowerCase();
-						}else{
-							newcol.index=document.getElementById("ColumnsWizard.id").value.toLowerCase();
+			if ("action" in args) {
+				switch (args.action) {
+					case "new": // Save new custom column
+						// fixed val
+						newcol.isBundled = false;
+						newcol.isCustom = true;
+						newcol.def = "";
+						// get userinput val
+						if (document.getElementById("ColumnsWizard.id").value.match(re_id) !== null) {
+							newcol.index = document.getElementById("ColumnsWizard.id").value.match(re_id).join('').toLowerCase();
+						} else {
+							newcol.index = document.getElementById("ColumnsWizard.id").value.toLowerCase();
 						}
-						//Check if the custom column is already present
-						//let prefsc = Components.classes["@mozilla.org/preferences-service;1"].getService(Components.interfaces.nsIPrefService);
-						//let prefs = prefsc.getBranch("extensions.ColumnsWizard.CustCols.");
-						//let CustColIndexStr=prefs.getCharPref("index");
-						let CustColIndexStr=miczColumnsWizardPrefsUtils.getCustColsIndex();
-						let CustColIndex=new Array();
-						if(CustColIndexStr!=''){
-							CustColIndex=JSON.parse(CustColIndexStr);
-							//dump(">>>>>>>>>>>>> miczColumnsWizard->onAccept: [newcol.index] "+JSON.stringify(newcol.index)+"\r\n");
-							if(CustColIndex.indexOf(newcol.index)!=-1){
-								//custom column already present
-								//dump(">>>>>>>>>>>>> miczColumnsWizard->onAccept: [CustColIndex] "+JSON.stringify(CustColIndex)+"\r\n");
-								let strBundleCW = Components.classes["@mozilla.org/intl/stringbundle;1"].getService(Components.interfaces.nsIStringBundleService);
+						// Check if the custom column is already present
+						// let prefsc = Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefService);
+						// let prefs = prefsc.getBranch("extensions.ColumnsWizard.CustCols.");
+						// let CustColIndexStr=prefs.getCharPref("index");
+						let CustColIndexStr = miczColumnsWizardPrefsUtils.getCustColsIndex();
+						let CustColIndex = [];
+						if (CustColIndexStr !== '') {
+							CustColIndex = JSON.parse(CustColIndexStr);
+							// dump(">>>>>>>>>>>>> miczColumnsWizard->onAccept: [newcol.index] "+JSON.stringify(newcol.index)+"\r\n");
+							if (CustColIndex.indexOf(newcol.index) !== -1) {
+								// custom column already present
+								// dump(">>>>>>>>>>>>> miczColumnsWizard->onAccept: [CustColIndex] "+JSON.stringify(CustColIndex)+"\r\n");
+								let strBundleCW = Cc["@mozilla.org/intl/stringbundle;1"].getService(Ci.nsIStringBundleService);
 								let _bundleCW = strBundleCW.createBundle("chrome://columnswizard/locale/mzcw-settings-customcolseditor.properties");
-								let prompts = Components.classes["@mozilla.org/embedcomp/prompt-service;1"].getService(Components.interfaces.nsIPromptService);
+								let prompts = Cc["@mozilla.org/embedcomp/prompt-service;1"].getService(Ci.nsIPromptService);
 								prompts.alert(window,
-											  _bundleCW.GetStringFromName("ColumnsWizard.emptyFields.title"),
-											  _bundleCW.GetStringFromName("ColumnsWizard.duplicatedID.text"));
+									_bundleCW.GetStringFromName("ColumnsWizard.emptyFields.title"),
+									_bundleCW.GetStringFromName("ColumnsWizard.duplicatedID.text"));
 								return false;
 							}
 						}
 
-						if(document.getElementById("ColumnsWizard.dbHeader").value.match(re_dbh)!=null){
-							newcol.dbHeader=document.getElementById("ColumnsWizard.dbHeader").value.match(re_dbh).join('').replace(':','');//.toLowerCase();
-						}else{
-							newcol.dbHeader=document.getElementById("ColumnsWizard.dbHeader").value.toLowerCase();
+						if (document.getElementById("ColumnsWizard.dbHeader").value.match(re_dbh) !== null) {
+							newcol.dbHeader = document.getElementById("ColumnsWizard.dbHeader").value.match(re_dbh).join('').replace(':', '');// .toLowerCase();
+						} else {
+							newcol.dbHeader = document.getElementById("ColumnsWizard.dbHeader").value.toLowerCase();
 						}
-						newcol.labelImagePath=miczColumnsWizardPref_CustColEditor.saveIcon(document.getElementById("ColumnsWizard.iconString").value,newcol.index);
-						newcol.labelString=document.getElementById("ColumnsWizard.labelString").value;
-						newcol.tooltipString=document.getElementById("ColumnsWizard.tooltipString").value;
-						newcol.sortnumber=document.getElementById("ColumnsWizard.sortnumber").checked;
-						newcol.isSearchable=document.getElementById("ColumnsWizard.searchable").checked;
-						newcol.enabled=document.getElementById("ColumnsWizard.enabled").checked;
+						newcol.labelImagePath = miczColumnsWizardPref_CustColEditor.saveIcon(document.getElementById("ColumnsWizard.iconString").value, newcol.index);
+						newcol.labelString = document.getElementById("ColumnsWizard.labelString").value;
+						newcol.tooltipString = document.getElementById("ColumnsWizard.tooltipString").value;
+						newcol.sortnumber = document.getElementById("ColumnsWizard.sortnumber").checked;
+						newcol.isSearchable = document.getElementById("ColumnsWizard.searchable").checked;
+						newcol.enabled = document.getElementById("ColumnsWizard.enabled").checked;
 
-						//mod data
-						newcol.isEditable=document.getElementById("ColumnsWizard.mod").checked;
-						newcol.editType=document.getElementById("ColumnsWizard.mod_type_group").value;
-						newcol.editFixedList=miczColumnsWizard_CustomColsModUtils.getFixedListArray(document.getElementById("ColumnsWizard.mod_type_fixedlist.list").value);
+						// mod data
+						newcol.isEditable = document.getElementById("ColumnsWizard.mod").checked;
+						newcol.editType = document.getElementById("ColumnsWizard.mod_type_group").value;
+						newcol.editFixedList = miczColumnsWizard_CustomColsModUtils.getFixedListArray(document.getElementById("ColumnsWizard.mod_type_fixedlist.list").value);
 
-						//dump(">>>>>>>>>>>>> miczColumnsWizard->onAccept: [newcol] "+JSON.stringify(newcol)+"\r\n");
-						//miczColumnsWizard_CustCols.addNewCustCol(newcol);
-						window.arguments[0].save=true;
-						window.arguments[0].newcol=newcol;
-					break;
-					case "edit":	//Modify the custom column
-						let currcol=JSON.parse(args.currcol);
-						//fixed val
-						newcol.isBundled=false;
-						newcol.isCustom=true;
-						newcol.def="";
-						//get userinput val
-						newcol.index=currcol.index;
-						newcol.dbHeader=currcol.dbHeader;
-						newcol.labelImagePath=miczColumnsWizardPref_CustColEditor.saveIcon(document.getElementById("ColumnsWizard.iconString").value,newcol.index);
-						if(newcol.labelImagePath==""){	//no image, try to delete it, maybe we are modifying and removing an image
+						// dump(">>>>>>>>>>>>> miczColumnsWizard->onAccept: [newcol] "+JSON.stringify(newcol)+"\r\n");
+						// miczColumnsWizard_CustCols.addNewCustCol(newcol);
+						window.arguments[0].save = true;
+						window.arguments[0].newcol = newcol;
+						break;
+					case "edit":	// Modify the custom column
+						let currcol = JSON.parse(args.currcol);
+						// fixed val
+						newcol.isBundled = false;
+						newcol.isCustom = true;
+						newcol.def = "";
+						// get userinput val
+						newcol.index = currcol.index;
+						newcol.dbHeader = currcol.dbHeader;
+						newcol.labelImagePath = miczColumnsWizardPref_CustColEditor.saveIcon(document.getElementById("ColumnsWizard.iconString").value, newcol.index);
+						if (newcol.labelImagePath === "") {	// no image, try to delete it, maybe we are modifying and removing an image
 							this.deleteIcon(newcol.dbHeader);
 						}
-						newcol.labelString=document.getElementById("ColumnsWizard.labelString").value;
-						newcol.tooltipString=document.getElementById("ColumnsWizard.tooltipString").value;
-						newcol.sortnumber=document.getElementById("ColumnsWizard.sortnumber").checked;
-						newcol.isSearchable=document.getElementById("ColumnsWizard.searchable").checked;
-						newcol.enabled=document.getElementById("ColumnsWizard.enabled").checked;
+						newcol.labelString = document.getElementById("ColumnsWizard.labelString").value;
+						newcol.tooltipString = document.getElementById("ColumnsWizard.tooltipString").value;
+						newcol.sortnumber = document.getElementById("ColumnsWizard.sortnumber").checked;
+						newcol.isSearchable = document.getElementById("ColumnsWizard.searchable").checked;
+						newcol.enabled = document.getElementById("ColumnsWizard.enabled").checked;
 
-						//mod data
-						newcol.isEditable=document.getElementById("ColumnsWizard.mod").checked;
-						newcol.editType=document.getElementById("ColumnsWizard.mod_type_group").value;
-						newcol.editFixedList=miczColumnsWizard_CustomColsModUtils.getFixedListArray(document.getElementById("ColumnsWizard.mod_type_fixedlist.list").value);
+						// mod data
+						newcol.isEditable = document.getElementById("ColumnsWizard.mod").checked;
+						newcol.editType = document.getElementById("ColumnsWizard.mod_type_group").value;
+						newcol.editFixedList = miczColumnsWizard_CustomColsModUtils.getFixedListArray(document.getElementById("ColumnsWizard.mod_type_fixedlist.list").value);
 
-						//dump(">>>>>>>>>>>>> miczColumnsWizard->onAccept: [newcol] "+JSON.stringify(newcol)+"\r\n");
-						//miczColumnsWizard_CustCols.addNewCustCol(newcol);
-						window.arguments[0].save=true;
-						window.arguments[0].newcol=newcol;
-					break;
+						// dump(">>>>>>>>>>>>> miczColumnsWizard->onAccept: [newcol] "+JSON.stringify(newcol)+"\r\n");
+						// miczColumnsWizard_CustCols.addNewCustCol(newcol);
+						window.arguments[0].save = true;
+						window.arguments[0].newcol = newcol;
+						break;
 				}
 			}
 		}
@@ -179,136 +180,137 @@ var miczColumnsWizardPref_CustColEditor = {
 		return true;
 	},
 
-	checkFields:function(){
-		//The fields must be filled!!
-		//The input are already sanitized elsewhere...
-		if((document.getElementById("ColumnsWizard.id").value=="")||(document.getElementById("ColumnsWizard.dbHeader").value=="")||(document.getElementById("ColumnsWizard.labelString").value=="")||(document.getElementById("ColumnsWizard.tooltipString").value=="")){
-			let strBundleCW = Components.classes["@mozilla.org/intl/stringbundle;1"].getService(Components.interfaces.nsIStringBundleService);
+	checkFields: function () {
+		// The fields must be filled!!
+		// The input are already sanitized elsewhere...
+		if ((document.getElementById("ColumnsWizard.id").value === "") || (document.getElementById("ColumnsWizard.dbHeader").value === "") || (document.getElementById("ColumnsWizard.labelString").value === "") || (document.getElementById("ColumnsWizard.tooltipString").value === "")) {
+			let strBundleCW = Cc["@mozilla.org/intl/stringbundle;1"].getService(Ci.nsIStringBundleService);
 			let _bundleCW = strBundleCW.createBundle("chrome://columnswizard/locale/mzcw-settings-customcolseditor.properties");
-			let prompts = Components.classes["@mozilla.org/embedcomp/prompt-service;1"].getService(Components.interfaces.nsIPromptService);
+			let prompts = Cc["@mozilla.org/embedcomp/prompt-service;1"].getService(Ci.nsIPromptService);
 			prompts.alert(window,
-                          _bundleCW.GetStringFromName("ColumnsWizard.emptyFields.title"),
-                          _bundleCW.GetStringFromName("ColumnsWizard.emptyFields.text"));
+				_bundleCW.GetStringFromName("ColumnsWizard.emptyFields.title"),
+				_bundleCW.GetStringFromName("ColumnsWizard.emptyFields.text"));
 			return false;
 		}
 		return true;
 	},
 
-	onBlur_sanitize_ID:function(){
-		let re=new RegExp(miczColumnsWizardPref_CustColEditor._sanitize_ID_regex,'ig');
-		let el=document.getElementById('ColumnsWizard.id');
-		if(el.value.match(re)!=null){
-			el.value=el.value.match(re).join('');
+	onBlur_sanitize_ID: function () {
+		let re = new RegExp(miczColumnsWizardPref_CustColEditor._sanitize_ID_regex, 'ig');
+		let el = document.getElementById('ColumnsWizard.id');
+		if (el.value.match(re) !== null) {
+			el.value = el.value.match(re).join('');
 		}
 	},
 
-	onBlur_sanitize_dbHeader:function(){
-		let re=new RegExp(miczColumnsWizardPref_CustColEditor._sanitize_dbHeader_regex,'g');
-		let el=document.getElementById('ColumnsWizard.dbHeader');
-		if(el.value.match(re)!=null){
-			el.value=el.value.match(re).join('').replace(':','');
+	onBlur_sanitize_dbHeader: function () {
+		let re = new RegExp(miczColumnsWizardPref_CustColEditor._sanitize_dbHeader_regex, 'g');
+		let el = document.getElementById('ColumnsWizard.dbHeader');
+		if (el.value.match(re) !== null) {
+			el.value = el.value.match(re).join('').replace(':', '');
 		}
-		//set the value on the label in the advanced tab
-		document.getElementById('cw_adv_msg_header').value=el.value;
+		// set the value on the label in the advanced tab
+		document.getElementById('cw_adv_msg_header').value = el.value;
 	},
 
-	setIconUI:function(iconpath){
-		document.getElementById("ColumnsWizard.iconString").setAttribute("value",iconpath);
-		//document.getElementById("ColumnsWizard.iconString").setAttribute("hidden",false);
-		document.getElementById("ColumnsWizard.setIcon_btn").setAttribute("image","file://"+iconpath);
-		document.getElementById("ColumnsWizard.removeIcon_btn").setAttribute("disabled",false);
+	setIconUI: function (iconpath) {
+		document.getElementById("ColumnsWizard.iconString").setAttribute("value", iconpath);
+		// document.getElementById("ColumnsWizard.iconString").setAttribute("hidden",false);
+		document.getElementById("ColumnsWizard.setIcon_btn").setAttribute("image", "file://" + iconpath);
+		document.getElementById("ColumnsWizard.removeIcon_btn").setAttribute("disabled", false);
 		this.fixWinHeight();
 	},
 
-	removeIconUI:function(){
-		document.getElementById("ColumnsWizard.iconString").setAttribute("value","");
-		//document.getElementById("ColumnsWizard.iconString").setAttribute("hidden",true);
-		document.getElementById("ColumnsWizard.setIcon_btn").setAttribute("image","");
-		document.getElementById("ColumnsWizard.removeIcon_btn").setAttribute("disabled",true);
+	removeIconUI: function () {
+		document.getElementById("ColumnsWizard.iconString").setAttribute("value", "");
+		// document.getElementById("ColumnsWizard.iconString").setAttribute("hidden",true);
+		document.getElementById("ColumnsWizard.setIcon_btn").setAttribute("image", "");
+		document.getElementById("ColumnsWizard.removeIcon_btn").setAttribute("disabled", true);
 		this.fixWinHeight();
 	},
 
-	chooseIcon:function(){
-		let strBundleCW = Components.classes["@mozilla.org/intl/stringbundle;1"].getService(Components.interfaces.nsIStringBundleService);
+	chooseIcon: function () {
+		let strBundleCW = Cc["@mozilla.org/intl/stringbundle;1"].getService(Ci.nsIStringBundleService);
 		let _bundleCW = strBundleCW.createBundle("chrome://columnswizard/locale/mzcw-settings-customcolseditor.properties");
-		let fp = Components.classes["@mozilla.org/filepicker;1"].createInstance(Components.interfaces.nsIFilePicker);
-		fp.init(window, _bundleCW.GetStringFromName("ColumnsWizard.chooseIcon.title")+"...", Components.interfaces.nsIFilePicker.modeOpen);
-    	fp.appendFilters(Components.interfaces.nsIFilePicker.filterImages);
+		let fp = Cc["@mozilla.org/filepicker;1"].createInstance(Ci.nsIFilePicker);
+		fp.init(window, _bundleCW.GetStringFromName("ColumnsWizard.chooseIcon.title") + "...", Ci.nsIFilePicker.modeOpen);
+		fp.appendFilters(Ci.nsIFilePicker.filterImages);
 
-    	let fpCallback = function fpCallback_done(aResult) {
-		//dump(">>>>>>>>>>>>> miczColumnsWizard->chooseIcon: [aResult] "+JSON.stringify(aResult)+"\r\n");
-		if (aResult == Components.interfaces.nsIFilePicker.returnOK) {
-			try {
-			  if (fp.file) {
-				//dump(">>>>>>>>>>>>> miczColumnsWizard->chooseIcon: [file.path] "+JSON.stringify(fp.file.path)+"\r\n");
-				miczColumnsWizardPref_CustColEditor.setIconUI(fp.file.path)
-			  }
-			} catch (ex) {
-				dump(">>>>>>>>>>>>> miczColumnsWizard->chooseIcon: [ex.message] "+JSON.stringify(ex.message)+"\r\n");
+		let fpCallback = function fpCallback_done(aResult) {
+			// dump(">>>>>>>>>>>>> miczColumnsWizard->chooseIcon: [aResult] "+JSON.stringify(aResult)+"\r\n");
+			if (aResult === Ci.nsIFilePicker.returnOK) {
+				try {
+					if (fp.file) {
+						// dump(">>>>>>>>>>>>> miczColumnsWizard->chooseIcon: [file.path] "+JSON.stringify(fp.file.path)+"\r\n");
+						miczColumnsWizardPref_CustColEditor.setIconUI(fp.file.path);
+					}
+				} catch (ex) {
+					dump(">>>>>>>>>>>>> miczColumnsWizard->chooseIcon: [ex.message] " + JSON.stringify(ex.message) + "\r\n");
+				}
 			}
-		  }
 		};
 
-		let localFile = Components.classes["@mozilla.org/file/local;1"].createInstance(Components.interfaces.nsIFile);
+		let localFile = Cc["@mozilla.org/file/local;1"].createInstance(Ci.nsIFile);
 		fp.displayDirectory = localFile;
 		fp.open(fpCallback);
 	},
 
-	saveIcon:function(filepath,newname){
-		if(filepath=="") return "";
-		//save the choosen icon in the user profile folder
-		let file = Components.classes["@mozilla.org/file/local;1"].createInstance(Components.interfaces.nsIFile);
+	saveIcon: function (filepath, newname) {
+		if (filepath === "") return "";
+		// save the choosen icon in the user profile folder
+		let file = Cc["@mozilla.org/file/local;1"].createInstance(Ci.nsIFile);
 		file.initWithPath(filepath);
 		try {
-			if(file){
-				let destPath = OS.Path.join(OS.Constants.Path.profileDir,"columnswizardmiczit");
-				OS.File.makeDir(destPath, {ignoreExisting: true});
-				let destFullPath=OS.Path.join(destPath,newname);
-				//dump(">>>>>>>>>>>>> miczColumnsWizard->saveIcon: [file.path] "+JSON.stringify(file.path)+"\r\n");
-				//dump(">>>>>>>>>>>>> miczColumnsWizard->saveIcon: [destPath] "+JSON.stringify(destPath)+"\r\n");
-				if(file.path.indexOf(destPath)==-1){	//if the icon is already in the dest folder (we're modifying a cust col), do nothing!
-					OS.File.copy(file.path,destFullPath);
+			if (file) {
+				let destPath = OS.Path.join(OS.Constants.Path.profileDir, "columnswizardmiczit");
+				OS.File.makeDir(destPath, { ignoreExisting: true });
+				let destFullPath = OS.Path.join(destPath, newname);
+				// dump(">>>>>>>>>>>>> miczColumnsWizard->saveIcon: [file.path] "+JSON.stringify(file.path)+"\r\n");
+				// dump(">>>>>>>>>>>>> miczColumnsWizard->saveIcon: [destPath] "+JSON.stringify(destPath)+"\r\n");
+				if (file.path.indexOf(destPath) === -1) {	// if the icon is already in the dest folder (we're modifying a cust col), do nothing!
+					OS.File.copy(file.path, destFullPath);
 				}
 				return destFullPath;
 			}
-		}catch(ex){
-			dump(">>>>>>>>>>>>> miczColumnsWizard->saveIcon: [ex.message] "+JSON.stringify(ex.message)+"\r\n");
+		} catch (ex) {
+			dump(">>>>>>>>>>>>> miczColumnsWizard->saveIcon: [ex.message] " + JSON.stringify(ex.message) + "\r\n");
 		}
+		return "";
 	},
 
-	deleteIcon:function(filename){
-		let destPath = OS.Path.join(OS.Constants.Path.profileDir,"columnswizardmiczit");
-		let filepath = OS.Path.join(destPath,filename);
+	deleteIcon: function (filename) {
+		let destPath = OS.Path.join(OS.Constants.Path.profileDir, "columnswizardmiczit");
+		let filepath = OS.Path.join(destPath, filename);
 		OS.File.remove(filepath);
 	},
 
-	enableAdvancedTabContent:function(){
-		let disabled=!document.getElementById('ColumnsWizard.mod').checked;
-		document.getElementById('ColumnsWizard.mod_type.desc').disabled=disabled;
-		document.getElementById('ColumnsWizard.mod_type_group').disabled=disabled;
+	enableAdvancedTabContent: function () {
+		let disabled = !document.getElementById('ColumnsWizard.mod').checked;
+		document.getElementById('ColumnsWizard.mod_type.desc').disabled = disabled;
+		document.getElementById('ColumnsWizard.mod_type_group').disabled = disabled;
 	},
-	
-	clickColumnsWizard_mod:function(){
-		document.getElementById('ColumnsWizard.mod2').checked=document.getElementById('ColumnsWizard.mod').checked;
-		miczColumnsWizardPref_CustColEditor.enableAdvancedTabContent();
-	},
-	
-	clickColumnsWizard_mod2:function(){
-		document.getElementById('ColumnsWizard.mod').checked=document.getElementById('ColumnsWizard.mod2').checked;
+
+	clickColumnsWizard_mod: function () {
+		document.getElementById('ColumnsWizard.mod2').checked = document.getElementById('ColumnsWizard.mod').checked;
 		miczColumnsWizardPref_CustColEditor.enableAdvancedTabContent();
 	},
 
-	enableHeaderFixedList:function(){
-		let disable=!document.getElementById('ColumnsWizard.mod_type_fixedlist').selected;
-		document.getElementById('ColumnsWizard.mod_type_fixedlist.list').disabled=disable;
-		document.getElementById('ColumnsWizard.mod_type_fixedlist.list.desc').disabled=disable;
+	clickColumnsWizard_mod2: function () {
+		document.getElementById('ColumnsWizard.mod').checked = document.getElementById('ColumnsWizard.mod2').checked;
+		miczColumnsWizardPref_CustColEditor.enableAdvancedTabContent();
 	},
 
-	sanitizeFixedListInput:function(){
-		document.getElementById("ColumnsWizard.mod_type_fixedlist.list").value=document.getElementById("ColumnsWizard.mod_type_fixedlist.list").value.replace("|"," ");
+	enableHeaderFixedList: function () {
+		let disable = !document.getElementById('ColumnsWizard.mod_type_fixedlist').selected;
+		document.getElementById('ColumnsWizard.mod_type_fixedlist.list').disabled = disable;
+		document.getElementById('ColumnsWizard.mod_type_fixedlist.list.desc').disabled = disable;
 	},
 
-	fixWinHeight:function(){
+	sanitizeFixedListInput: function () {
+		document.getElementById("ColumnsWizard.mod_type_fixedlist.list").value = document.getElementById("ColumnsWizard.mod_type_fixedlist.list").value.replace("|", " ");
+	},
+
+	fixWinHeight: function () {
 		sizeToContent();
 		var vbox = document.getElementById('cw_vbox');
 		vbox.height = vbox.boxObject.height;

--- a/src/chrome/content/mzcw-settings.js
+++ b/src/chrome/content/mzcw-settings.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
 ChromeUtils.import("chrome://columnswizard/content/mzcw-customcolsgrid.jsm");
 ChromeUtils.import("chrome://columnswizard/content/mzcw-defaultcolsgrid.jsm");
 
@@ -115,8 +116,7 @@ var miczColumnsWizardPref = {
 
 		// Are you sure?
 		let prompts = Cc["@mozilla.org/embedcomp/prompt-service;1"].getService(Ci.nsIPromptService);
-		let strBundleCW = Cc["@mozilla.org/intl/stringbundle;1"].getService(Ci.nsIStringBundleService);
-		let _bundleCW = strBundleCW.createBundle("chrome://columnswizard/locale/settings.properties");
+		let _bundleCW = Services.strings.createBundle("chrome://columnswizard/locale/settings.properties");
 
 		if (!prompts.confirm(null, _bundleCW.GetStringFromName("ColumnsWizard.deletePrompt.title"), _bundleCW.GetStringFromName("ColumnsWizard.deletePrompt.text"))) return;
 

--- a/src/chrome/content/mzcw-settings.js
+++ b/src/chrome/content/mzcw-settings.js
@@ -1,18 +1,21 @@
 "use strict";
+
 ChromeUtils.import("chrome://columnswizard/content/mzcw-customcolsgrid.jsm");
 ChromeUtils.import("chrome://columnswizard/content/mzcw-defaultcolsgrid.jsm");
-Components.utils.importGlobalProperties(["XMLHttpRequest"]);
 
-var miczColumnsWizard=window.opener.miczColumnsWizard;
+// Check
+// Cu.importGlobalProperties(["XMLHttpRequest"]);
+
+var miczColumnsWizard = window.opener.miczColumnsWizard;
 var miczColumnsWizardPref = {
 
-	onLoad: function(win){
+	onLoad: function (win) {
 		this.loadCustColRows(win);
 
-		//Load release notes
+		// Load release notes
 		this.loadInfoFile('release_notes');
 
-		//Fixing window height
+		// Fixing window height
 		sizeToContent();
 		var vbox = document.getElementById('cw_tabbox');
 		vbox.height = vbox.boxObject.height;
@@ -20,132 +23,132 @@ var miczColumnsWizardPref = {
 
 		this.loadDefaultColRows(win);
 
-		miczColumnsWizardPref_CustomColsGrid.miczColumnsWizard_CustCols=miczColumnsWizard_CustCols;
-		miczColumnsWizardPref_CustomColsGrid.win=win;
-		miczColumnsWizardPref_CustomColsGrid.onEditCustomCol=miczColumnsWizardPref.onEditCustomCol;
+		miczColumnsWizardPref_CustomColsGrid.miczColumnsWizard_CustCols = miczColumnsWizard_CustCols;
+		miczColumnsWizardPref_CustomColsGrid.win = win;
+		miczColumnsWizardPref_CustomColsGrid.onEditCustomCol = miczColumnsWizardPref.onEditCustomCol;
 	},
 
-	loadDefaultColRows:function(win){
+	loadDefaultColRows: function (win) {
 		let doc = win.document;
 		let container = doc.getElementById('ColumnsWizard.DefaultColsGrid');
-		miczColumnsWizardPref_DefaultColsGrid.loadedCustCols=miczColumnsWizard_CustCols.loadCustCols();
-		miczColumnsWizardPref_DefaultColsGrid.createDefaultColsGridHeader(doc,container);
-		miczColumnsWizardPref_DefaultColsGrid.createDefaultColsGridRows(doc,container);
+		miczColumnsWizardPref_DefaultColsGrid.loadedCustCols = miczColumnsWizard_CustCols.loadCustCols();
+		miczColumnsWizardPref_DefaultColsGrid.createDefaultColsGridHeader(doc, container);
+		miczColumnsWizardPref_DefaultColsGrid.createDefaultColsGridRows(doc, container);
 	},
 
-	saveDefaultColRows:function(win){
+	saveDefaultColRows: function (win) {
 		let doc = win.document;
 		let container = doc.getElementById('ColumnsWizard.DefaultColsGrid');
-		//dump(">>>>>>>>>>>>> miczColumnsWizard: [miczColumnsWizardPref] saveDefaultColRows called\r\n");
-		return miczColumnsWizardPref_DefaultColsGrid.saveDefaultColsGridRows(doc,container,false);
+		// dump(">>>>>>>>>>>>> miczColumnsWizard: [miczColumnsWizardPref] saveDefaultColRows called\r\n");
+		return miczColumnsWizardPref_DefaultColsGrid.saveDefaultColsGridRows(doc, container, false);
 	},
 
-	loadCustColRows:function(win){
+	loadCustColRows: function (win) {
 		let doc = win.document;
 		let container = doc.getElementById('ColumnsWizard.CustColsList');
-		miczColumnsWizardPref_CustomColsGrid.createCustomColsListRows(doc,container,miczColumnsWizard_CustCols.loadCustCols());
+		miczColumnsWizardPref_CustomColsGrid.createCustomColsListRows(doc, container, miczColumnsWizard_CustCols.loadCustCols());
 	},
 
-	updateButtons: function(win){
+	updateButtons: function (win) {
 		let doc = win.document;
-		let currlist=doc.getElementById('ColumnsWizard.CustColsList');
+		let currlist = doc.getElementById('ColumnsWizard.CustColsList');
 		let numSelected = currlist.selectedItems.length;
-		let oneSelected = (numSelected == 1);
-		if(oneSelected){
-			//if it's a bundled item, we can not modify or delete it!
-			let currcol=miczColumnsWizardPref_CustomColsGrid.currentCustomCol(currlist);
+		let oneSelected = (numSelected === 1);
+		if (oneSelected) {
+			// if it's a bundled item, we can not modify or delete it!
+			let currcol = miczColumnsWizardPref_CustomColsGrid.currentCustomCol(currlist);
 			let btnDisabled = currcol.isBundled;
-			//dump(">>>>>>>>>>>>> miczColumnsWizard: [updateButtons] currlist.selectedItem "+JSON.stringify(currcol)+"\r\n");
-			//dump(">>>>>>>>>>>>> miczColumnsWizard: [updateButtons] col_index {"+currcol.index+"}\r\n");
-			//dump(">>>>>>>>>>>>> miczColumnsWizard: [updateButtons] btnDisabled {"+btnDisabled+"}\r\n");
-			doc.getElementById("editButton").disabled=btnDisabled;
-			doc.getElementById("deleteButton").disabled=btnDisabled;
+			// dump(">>>>>>>>>>>>> miczColumnsWizard: [updateButtons] currlist.selectedItem "+JSON.stringify(currcol)+"\r\n");
+			// dump(">>>>>>>>>>>>> miczColumnsWizard: [updateButtons] col_index {"+currcol.index+"}\r\n");
+			// dump(">>>>>>>>>>>>> miczColumnsWizard: [updateButtons] btnDisabled {"+btnDisabled+"}\r\n");
+			doc.getElementById("editButton").disabled = btnDisabled;
+			doc.getElementById("deleteButton").disabled = btnDisabled;
 		}
-		//dump(">>>>>>>>>>>>> miczColumnsWizard: [updateButtons] currlist num selected {"+numSelected+"}\r\n");
+		// dump(">>>>>>>>>>>>> miczColumnsWizard: [updateButtons] currlist num selected {"+numSelected+"}\r\n");
 	},
 
-	onNewCustomCol: function(win){
+	onNewCustomCol: function (win) {
 		let doc = win.document;
 		let container = doc.getElementById('ColumnsWizard.CustColsList');
-		let args = {"action":"new"};
+		let args = { "action": "new" };
 
 		window.openDialog("chrome://columnswizard/content/mzcw-settings-customcolseditor.xul", "CustColsEditor", "chrome,modal,titlebar,resizable,centerscreen", args);
 
-		if (("save" in args && args.save)&& ("newcol" in args && args.newcol)){
+		if (("save" in args && args.save) && ("newcol" in args && args.newcol)) {
 			miczColumnsWizard_CustCols.addNewCustCol(args.newcol);
-			miczColumnsWizardPref_CustomColsGrid.createOneCustomColRow(doc,container,args.newcol);
+			miczColumnsWizardPref_CustomColsGrid.createOneCustomColRow(doc, container, args.newcol);
 			// Select the new custcols, it is at the end of the list.
-			container.selectedIndex=container.itemCount-1;
+			container.selectedIndex = container.itemCount - 1;
 			container.ensureIndexIsVisible(container.selectedIndex);
 		}
 
 	},
 
-	onEditCustomCol: function(win){
+	onEditCustomCol: function (win) {
 		let doc = win.document;
 		let container = doc.getElementById('ColumnsWizard.CustColsList');
 
-		if(container.selectedIndex==-1) return;
-		if(doc.getElementById("editButton").disabled) return;
+		if (container.selectedIndex === -1) return;
+		if (doc.getElementById("editButton").disabled) return;
 
-		let args = {"action":"edit","currcol":JSON.stringify(container.selectedItem._customcol)};
+		let args = { "action": "edit", "currcol": JSON.stringify(container.selectedItem._customcol) };
 
 		window.openDialog("chrome://columnswizard/content/mzcw-settings-customcolseditor.xul", "CustColsEditor", "chrome,modal,titlebar,resizable,centerscreen", args);
 
-		if (("save" in args && args.save)&& ("newcol" in args && args.newcol)){
-			//save the cust col in the pref
+		if (("save" in args && args.save) && ("newcol" in args && args.newcol)) {
+			// save the cust col in the pref
 			miczColumnsWizard_CustCols.updateCustCol(args.newcol);
-			//update the cust col in the listbox
-			miczColumnsWizardPref_CustomColsGrid.editOneCustomColRow(doc,container,args.newcol,container.selectedIndex);
+			// update the cust col in the listbox
+			miczColumnsWizardPref_CustomColsGrid.editOneCustomColRow(doc, container, args.newcol, container.selectedIndex);
 			// Select the editedcustcols
 			container.ensureIndexIsVisible(container.selectedIndex);
 		}
 
 	},
 
-	onDeleteCustomCol: function(win){
+	onDeleteCustomCol: function (win) {
 		let doc = win.document;
 		let container = doc.getElementById('ColumnsWizard.CustColsList');
 
-		if(container.selectedIndex==-1) return;
-		if(doc.getElementById("deleteButton").disabled) return;
+		if (container.selectedIndex === -1) return;
+		if (doc.getElementById("deleteButton").disabled) return;
 
-		//Are you sure?
-		let prompts = Components.classes["@mozilla.org/embedcomp/prompt-service;1"].getService(Components.interfaces.nsIPromptService);
-		let strBundleCW = Components.classes["@mozilla.org/intl/stringbundle;1"].getService(Components.interfaces.nsIStringBundleService);
+		// Are you sure?
+		let prompts = Cc["@mozilla.org/embedcomp/prompt-service;1"].getService(Ci.nsIPromptService);
+		let strBundleCW = Cc["@mozilla.org/intl/stringbundle;1"].getService(Ci.nsIStringBundleService);
 		let _bundleCW = strBundleCW.createBundle("chrome://columnswizard/locale/settings.properties");
 
-		if(!prompts.confirm(null,_bundleCW.GetStringFromName("ColumnsWizard.deletePrompt.title"),_bundleCW.GetStringFromName("ColumnsWizard.deletePrompt.text"))) return;
+		if (!prompts.confirm(null, _bundleCW.GetStringFromName("ColumnsWizard.deletePrompt.title"), _bundleCW.GetStringFromName("ColumnsWizard.deletePrompt.text"))) return;
 
-		//get the col id
-		let col_idx=container.selectedItem._customcol.index;
-		//dump(">>>>>>>>>>>>> miczColumnsWizard: [onDeleteCustomCol] col_idx ["+col_idx+"]\r\n");
+		// get the col id
+		let col_idx = container.selectedItem._customcol.index;
+		// dump(">>>>>>>>>>>>> miczColumnsWizard: [onDeleteCustomCol] col_idx ["+col_idx+"]\r\n");
 
-		//delete the custom col
-		let ObserverService = Components.classes["@mozilla.org/observer-service;1"].getService(Components.interfaces.nsIObserverService);
-		//miczColumnsWizard_CustCols.removeCustomColumn(col_idx,ObserverService)
-		//miczColumnsWizard_CustCols.deleteCustCol(col_idx);
-		ObserverService.notifyObservers(null,"CW-deleteCustomColumn",col_idx);
+		// delete the custom col
+		let ObserverService = Cc["@mozilla.org/observer-service;1"].getService(Ci.nsIObserverService);
+		// miczColumnsWizard_CustCols.removeCustomColumn(col_idx,ObserverService)
+		// miczColumnsWizard_CustCols.deleteCustCol(col_idx);
+		ObserverService.notifyObservers(null, "CW-deleteCustomColumn", col_idx);
 
-		//remove the custom col from the listbox
-		miczColumnsWizardPref_CustomColsGrid.deleteOneCustomColRow(container,container.selectedIndex);
+		// remove the custom col from the listbox
+		miczColumnsWizardPref_CustomColsGrid.deleteOneCustomColRow(container, container.selectedIndex);
 	},
 
-	loadInfoFile:function(filetype){
+	loadInfoFile: function (filetype) {
 		let url = '';
-		switch(filetype){
+		switch (filetype) {
 			case 'release_notes':
-				url ="chrome://cwrl/content/release_notes.txt";
+				url = "chrome://cwrl/content/release_notes.txt";
 				break;
 			case 'license':
-				url ="chrome://cwrl/content/license.txt";
+				url = "chrome://cwrl/content/license.txt";
 				break;
-		 }
+		}
 		let request = new XMLHttpRequest();
-		request.responseType="text";
-		request.addEventListener("load", function() {
+		request.responseType = "text";
+		request.addEventListener("load", function () {
 			let relnotes = document.getElementById('mzcw-release-notes');
-			relnotes.value= this.responseText;
+			relnotes.value = this.responseText;
 		});
 		request.open("GET", url);
 		request.send();

--- a/src/chrome/content/mzcw-utils.jsm
+++ b/src/chrome/content/mzcw-utils.jsm
@@ -1,26 +1,27 @@
 "use strict";
 
-let EXPORTED_SYMBOLS = ["miczColumnsWizardUtils"];
+var EXPORTED_SYMBOLS = ["miczColumnsWizardUtils"];
 
 
 var miczColumnsWizardUtils = {
 
-	Services:ChromeUtils.import("resource://gre/modules/Services.jsm"),
-	mHost:null,
+	Services: ChromeUtils.import("resource://gre/modules/Services.jsm"),
+	mHost: null,
 
-	get HostSystem(){
-		if (null==miczColumnsWizardUtils.mHost){
-			let osString = Components.classes["@mozilla.org/xre/app-info;1"].getService(Components.interfaces.nsIXULRuntime).OS;
+	get HostSystem() {
+		if (null === miczColumnsWizardUtils.mHost) {
+			let osString = Cc["@mozilla.org/xre/app-info;1"].getService(Ci.nsIXULRuntime).OS;
 			miczColumnsWizardUtils.mHost = osString.toLowerCase();
 		}
 		return miczColumnsWizardUtils.mHost; // linux - winnt - darwin
 	},
 
-	/*getMail3PaneWindow:function getMail3PaneWindow(){
-		let windowManager = Components.classes['@mozilla.org/appshell/window-mediator;1']
-				.getService(Components.interfaces.nsIWindowMediator),
+	/* getMail3PaneWindow:function getMail3PaneWindow(){
+		let windowManager = Cc['@mozilla.org/appshell/window-mediator;1']
+				.getService(Ci.nsIWindowMediator),
 		    win3pane = windowManager.getMostRecentWindow("mail:3pane");
 		return win3pane;
-	},*/
+	},
+	*/
 
 };

--- a/src/chrome/content/mzcw-utils.jsm
+++ b/src/chrome/content/mzcw-utils.jsm
@@ -2,7 +2,6 @@
 
 var EXPORTED_SYMBOLS = ["miczColumnsWizardUtils"];
 
-
 var miczColumnsWizardUtils = {
 
 	Services: ChromeUtils.import("resource://gre/modules/Services.jsm"),

--- a/src/chrome/resource/miczLogger.jsm
+++ b/src/chrome/resource/miczLogger.jsm
@@ -1,24 +1,23 @@
 "use strict";
-const {classes: Cc, interfaces: Ci, utils: Cu, results : Cr} = Components;
 
 let EXPORTED_SYMBOLS = ["miczLogger"];
 
 var miczLogger = {
-	active:true,
-	consoleService:null,
-	debug:false,
+	active: true,
+	consoleService: null,
+	debug: false,
 
-	setLogger:function(active,debug){
-		this.active=active;
-		this.debug=debug;
+	setLogger: function (active, debug) {
+		this.active = active;
+		this.debug = debug;
 	},
 
-	setActive:function(active){
-		this.active=active;
+	setActive: function (active) {
+		this.active = active;
 	},
 
-	setDebug:function(debug){
-		this.debug=debug;
+	setDebug: function (debug) {
+		this.debug = debug;
 	},
 
 	logTime: function logTime() {
@@ -26,29 +25,29 @@ var miczLogger = {
 		return end.getHours() + ':' + end.getMinutes() + ':' + end.getSeconds() + '.' + end.getMilliseconds();
 	},
 
-	log:function(msg,level = 0){ //level 0: msg, 1: warning, 2: critical error
-		if (this.consoleService === null){
-			this.consoleService = Components.classes["@mozilla.org/consoleservice;1"].getService(Components.interfaces.nsIConsoleService);
+	log: function (msg, level = 0) { // level 0: msg, 1: warning, 2: critical error
+		if (this.consoleService === null) {
+			this.consoleService = Cc["@mozilla.org/consoleservice;1"].getService(Ci.nsIConsoleService);
 		}
 
-		if((level==0)&&(this.debug)){
-			this.consoleService.logStringMessage("ColumnsWizard >>> " + this.logTime() + "\n"+ msg);
-		}else if(level>0){
+		if ((level === 0) && (this.debug)) {
+			this.consoleService.logStringMessage("ColumnsWizard >>> " + this.logTime() + "\n" + msg);
+		} else if (level > 0) {
 			// flags
 			// errorFlag    0x0   Error messages. A pseudo-flag for the default, error case.
 			// warningFlag    0x1   Warning messages.
 			// exceptionFlag  0x2   An exception was thrown for this case - exception-aware hosts can ignore this.
 			// strictFlag     0x4
 			let aCategory = '';
-        	let scriptError = Components.classes["@mozilla.org/scripterror;1"].createInstance(Components.interfaces.nsIScriptError);
-        	let aFlags=0x0;
-        	if(level==1) aFlags=0x1;
-        	let aSourceName='ColumnsWizard',
-        	aSourceLine='Error dumped by miczLogger...',
-        	aLineNumber=0,
-        	aColumnNumber=0;
-    		scriptError.init(msg, aSourceName, aSourceLine, aLineNumber, aColumnNumber, aFlags, aCategory);
-    		this.consoleService.logMessage(scriptError);
+			let scriptError = Cc["@mozilla.org/scripterror;1"].createInstance(Ci.nsIScriptError);
+			let aFlags = 0x0;
+			if (level === 1) aFlags = 0x1;
+			let aSourceName = 'ColumnsWizard',
+				aSourceLine = 'Error dumped by miczLogger...',
+				aLineNumber = 0,
+				aColumnNumber = 0;
+			scriptError.init(msg, aSourceName, aSourceLine, aLineNumber, aColumnNumber, aFlags, aCategory);
+			this.consoleService.logMessage(scriptError);
 		}
 	},
 };


### PR DESCRIPTION
- Use eslint/recommended
- Use Mozilla/recommended - disable certain rules
- Define globals in rubles file
- update indexOf => includes
- Use C* updated syntax instead of Components.*
- Use .remove
- Force eqeqeq for  ===  & !==
- Enforce various spacing formatting


@micz 
I made a significant pass to align with common rules and formatting.  Also setting the stage for necessary API and web extension requirements.